### PR TITLE
[Refactor/#37] 수기 작성 api 분리

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,35 +1,32 @@
 from fastapi import Depends, HTTPException, APIRouter, UploadFile, File
+from sqlalchemy import asc
 from sqlalchemy.orm import Session, joinedload
 from datetime import date as _date
 
 from starlette.responses import JSONResponse
 
 from app.core.db import get_db
-from app.db_models.record_exchange import RecordExchange
 
 from app.db_models.record import Record
+from app.db_models.record_exchange import RecordExchange
 
-from app.models.recordSchemas import RecordCreate, RecordPatch
+from app.models.recordSchemas import RecordCommonPatch, RecordCommonCreate, RecordExchangeCreate, RecordExchangePatch
 from app.services.ocrService import OcrError, ocr_bytes_to_pdrecord_json, save_pdrecord_json, _record_to_dict
-from app.services.recordService import parse_time, rec_to_dict, apply_patch
+from app.services.recordService import rec_to_dict, apply_record_patch, upsert_exchange, ex_to_dict
 
 router = APIRouter()
 
 
-# 복막투석기록 생성 api
+# 복막투석기록 공통 정보 생성 api
 @router.post(
     "/api/v1/records",
-    tags=["복막투석기록"],
-    summary="기록 생성",
-    description="복막투석기록(일일 공통 + 회차들)을 생성하는 API입니다."
+    tags=["복막투석기록-공통"],
+    summary="공통 정보 생성",
+    description="회차 없이 공통 정보만 생성합니다."
 )
-def create_record(payload: RecordCreate, db: Session = Depends(get_db)):
-    try:
-        d = _date.fromisoformat(payload.record_date) if payload.record_date else _date.today()
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"record_date 오류: {e}")
+def create_record_common(payload: RecordCommonCreate, db: Session = Depends(get_db)):
+    d = payload.record_date or _date.today()
 
-    # 레코드 생성 (공통)
     rec = Record(
         record_date=d,
         record_dw=payload.record_dw,
@@ -40,72 +37,165 @@ def create_record(payload: RecordCreate, db: Session = Depends(get_db)):
         urine_count=payload.urine_count,
         turbidity=payload.turbidity,
         notes=payload.notes,
-        total_uf=payload.total_uf
+        total_uf=payload.total_uf, # 합계는 선택 입력(후입력 가능)
     )
-
-    # 회차(개별) 생성
-    seen_no = set()
-    for ex in payload.exchanges or []:
-        if ex.exchange_no in seen_no:
-            raise HTTPException(status_code=400, detail=f"회차 번호 중복: {ex.exchange_no}")
-        seen_no.add(ex.exchange_no)
-
-        try:
-            t = parse_time(ex.exchange_time)
-        except Exception as e:
-            raise HTTPException(status_code=400, detail=f"exchange_time 오류(회차 {ex.exchange_no}): {e}")
-
-        rec.exchanges.append(
-            RecordExchange(
-                exchange_no=ex.exchange_no,
-                exchange_time=t,
-                drain_volume=ex.drain_volume,
-                fill_volume=ex.fill_volume,
-                fill_concentration=ex.fill_concentration,
-                uf=ex.uf
-            )
-        )
 
     db.add(rec)
     db.commit()
     db.refresh(rec)
     return rec_to_dict(rec)
 
-
-# 특정 복막투석기록 조회 api
-@router.get(
-    "/api/v1/records/{rec_id}",
-    tags=["복막투석기록"],
-    summary="기록 조회",
-    description="특정 복막투석기록(일일 공통 + 회차들)을 조회합니다."
-)
-def get_record(rec_id: int, db: Session = Depends(get_db)):
-    rec = db.get(Record, rec_id)
-    if not rec:
-        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
-    return rec_to_dict(rec)
-
-
-# 복막투석기록 수정 api (부분 수정)
+# 복막투석기록 공통 정보 수정 api
 @router.patch(
     "/api/v1/records/{rec_id}",
-    tags=["복막투석기록"],
-    summary="기록 수정",
-    description="복막투석기록을 부분 수정합니다. 회차 필드가 포함되면 해당 회차를 upsert합니다."
+    tags=["복막투석기록-공통"],
+    summary="공통 정보 수정",
+    description="공통 정보만 부분 수정합니다."
 )
-def patch_record(rec_id: int, payload: RecordPatch, db: Session = Depends(get_db)):
+def patch_record_common(rec_id: int, payload: RecordCommonPatch, db: Session = Depends(get_db)):
     rec = db.get(Record, rec_id)
     if not rec:
         raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
 
     patch = payload.model_dump(exclude_unset=True)
-    # apply_patch가 일일 공통 + 회차 upsert를 함께 처리
-    apply_patch(rec, patch)
+    apply_record_patch(rec, patch)
 
     db.add(rec)
     db.commit()
     db.refresh(rec)
     return rec_to_dict(rec)
+
+# 복막투석기록 회차 정보 생성 api
+@router.post(
+    "/api/v1/records/{rec_id}/exchanges",
+    tags=["복막투석기록-회차"],
+    summary="회차 정보 생성",
+    description="특정 기록에 회차 정보를 생성합니다."
+)
+def upsert_record_exchange(rec_id: int, payload: RecordExchangeCreate, db: Session = Depends(get_db)):
+    rec = db.get(Record, rec_id)
+    if not rec:
+        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
+
+    p = payload.model_dump()
+    upsert_exchange(rec, p)
+
+    db.add(rec)
+    db.commit()
+    db.refresh(rec)
+    return rec_to_dict(rec)
+
+# 복막투석기록 회차 정보 수정 api
+@router.patch(
+    "/api/v1/records/{rec_id}/exchanges/{exchange_no}",
+    tags=["복막투석기록-회차"],
+    summary="회차 정보 수정",
+    description="특정 기록의 특정 회차 정보를 수정합니다."
+)
+def patch_record_exchange(rec_id: int, exchange_no: int, payload: RecordExchangePatch, db: Session = Depends(get_db)):
+    rec = db.get(Record, rec_id)
+    if not rec:
+        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
+
+    p = payload.model_dump(exclude_unset=True)
+    p["exchange_no"] = p.get("exchange_no", exchange_no)
+
+    upsert_exchange(rec, p)
+
+    db.add(rec)
+    db.commit()
+    db.refresh(rec)
+    return rec_to_dict(rec)
+
+# 특정 복막투석기록 조회 api (공통 + 회차)
+@router.get(
+    "/api/v1/records/{rec_id}",
+    tags=["복막투석기록"],
+    summary="전체 기록 조회",
+    description="특정 복막투석기록(공통 + 회차 전체)을 조회합니다."
+)
+def get_record(rec_id: int, db: Session = Depends(get_db)):
+    rec = db.get(Record, rec_id)
+    if not rec:
+        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
+    rec = (
+        db.query(Record)
+        .options(joinedload(Record.exchanges))
+        .filter(Record.id == rec_id)
+        .one()
+    )
+    return rec_to_dict(rec)
+
+# 특정 복막투석기록 조회 (공통)
+@router.get(
+    "/api/v1/records/{rec_id}/common",
+    tags=["복막투석기록-공통"],
+    summary="공통 정보 조회",
+    description="특정 기록(rec_id)의 공통정보를 조회합니다."
+)
+def get_record_common(rec_id: int, db: Session = Depends(get_db)):
+    rec = db.get(Record, rec_id)
+    if not rec:
+        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
+
+    return {
+        "id": rec.id,
+        "record_date": rec.record_date,
+        "record_dw": rec.record_dw,
+        "weight": rec.weight,
+        "systolic": rec.systolic,
+        "diastolic": rec.diastolic,
+        "fasting_glucose": rec.fasting_glucose,
+        "urine_count": rec.urine_count,
+        "turbidity": rec.turbidity,
+        "notes": rec.notes,
+        "total_uf": rec.total_uf
+    }
+
+# 특정 복막투석기록의 회차정보 목록 조회
+@router.get(
+    "/api/v1/records/{rec_id}/exchanges",
+    tags=["복막투석기록-회차"],
+    summary="회차 목록 조회",
+    description="특정 기록(rec_id)의 회차 목록을 조회합니다."
+)
+def list_record_exchanges(rec_id: int, db: Session = Depends(get_db)):
+    rec = db.get(Record, rec_id)
+    if not rec:
+        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
+
+    # 같은 기록에 속한 회차만 정렬해서 반환
+    rows = (
+        db.query(RecordExchange)
+        .filter(RecordExchange.record_id == rec_id)
+        .order_by(asc(RecordExchange.exchange_no))
+        .all()
+    )
+    return [ex_to_dict(e) for e in rows]
+
+# 특정 복막투석기록 회차 정보 조회
+@router.get(
+    "/api/v1/records/{rec_id}/exchanges/{exchange_id}",
+    tags=["복막투석기록-회차"],
+    summary="회차 단건 조회",
+    description="특정 기록의 회차 중 교체 ID(RecordExchange.id)로 단건 조회합니다."
+)
+def get_record_exchange_by_id(rec_id: int, exchange_id: int, db: Session = Depends(get_db)):
+    rec = db.get(Record, rec_id)
+    if not rec:
+        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
+
+    row = (
+        db.query(RecordExchange)
+        .filter(
+            RecordExchange.record_id == rec_id,
+            RecordExchange.id == exchange_id
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="해당 회차를 찾을 수 없습니다.")
+    return ex_to_dict(row)
 
 
 # 파일 업로드 -> OCR 텍스트 추출 -> JSON 반환 -> db 저장 api

--- a/app/models/recordSchemas.py
+++ b/app/models/recordSchemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime, date
-from typing import Optional, Literal, List, Annotated
+from typing import Optional, Literal
 from pydantic import BaseModel, Field, ConfigDict
 
 # 오늘 기본값 예시 구성
@@ -21,7 +21,7 @@ class RecordExchangeCreate(ORMBase):
         json_schema_extra={
             "example": {
                 "exchange_no": 1,
-                "exchange_time": time_str,   # "HH:MM"
+                "exchange_time": time_str,
                 "drain_volume": 2100,
                 "fill_volume": 2000,
                 "fill_concentration": 2.5,
@@ -57,7 +57,7 @@ class RecordExchangePatch(ORMBase):
 class RecordExchangeRead(ORMBase):
     id: int
     exchange_no: int
-    exchange_time: str     # "HH:MM"
+    exchange_time: str
     drain_volume: int
     fill_volume: int
     fill_concentration: float
@@ -77,7 +77,7 @@ class RecordCommonCreate(ORMBase):
                 "urine_count": 6,
                 "turbidity": "없음",
                 "notes": "환자의 상태 양호",
-                "total_uf": 150 # total_uf는 환자 수기 입력으로 '나중에' 입력해도 되므로 Optional
+                "total_uf": 150 # total_uf는 현재 구조 상 나중 입력
             }
         }
     )

--- a/app/models/recordSchemas.py
+++ b/app/models/recordSchemas.py
@@ -1,27 +1,27 @@
-from datetime import datetime
+from datetime import datetime, date
 from typing import Optional, Literal, List, Annotated
 from pydantic import BaseModel, Field, ConfigDict
 
+# 오늘 기본값 예시 구성
 today = datetime.now()
 today_str = today.strftime("%Y-%m-%d")
 time_str = today.strftime("%H:%M")
-weekday_kr = ["월","화","수","목","금","토","일"]
+weekday_kr = ["월", "화", "수", "목", "금", "토", "일"]
 today_dw = weekday_kr[today.weekday()]
-
 
 class ORMBase(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-DayWeekKR = Literal["월","화","수","목","금","토","일"]
+DayWeekKR = Literal["월", "화", "수", "목", "금", "토", "일"]
 Turbidity = Literal["없음", "있음"]
 
-# 회차(개별) 스키마
+# 회차 정보 생성 스키마
 class RecordExchangeCreate(ORMBase):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
                 "exchange_no": 1,
-                "exchange_time": time_str,
+                "exchange_time": time_str,   # "HH:MM"
                 "drain_volume": 2100,
                 "fill_volume": 2000,
                 "fill_concentration": 2.5,
@@ -34,9 +34,9 @@ class RecordExchangeCreate(ORMBase):
     drain_volume: int = Field(..., ge=0, le=6000)
     fill_volume: int = Field(..., ge=0, le=6000)
     fill_concentration: float = Field(..., ge=0, le=100, description="예: 1.5, 2.5, 4.25")
-    uf: int = Field(..., ge=-500, le=500)
+    uf: int = Field(..., ge=-500, le=500, description="제수량(-500~500)")
 
-
+# 회차 정보 수정 스키마
 class RecordExchangePatch(ORMBase):
     model_config = ConfigDict(
         json_schema_extra={
@@ -53,17 +53,18 @@ class RecordExchangePatch(ORMBase):
     fill_concentration: Optional[float] = Field(None, ge=0, le=100)
     uf: Optional[int] = Field(None, ge=-500, le=500)
 
+# 회차 정보 조회 스키마
 class RecordExchangeRead(ORMBase):
     id: int
     exchange_no: int
-    exchange_time: str
+    exchange_time: str     # "HH:MM"
     drain_volume: int
     fill_volume: int
     fill_concentration: float
     uf: int
 
-
-class RecordCreate(ORMBase):
+# 공통 정보 생성 스키마
+class RecordCommonCreate(ORMBase):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
@@ -76,53 +77,34 @@ class RecordCreate(ORMBase):
                 "urine_count": 6,
                 "turbidity": "없음",
                 "notes": "환자의 상태 양호",
-                "total_uf": "150",
-                "exchanges": [
-                    {
-                        "exchange_no": 1,
-                        "exchange_time": "07:30",
-                        "drain_volume": 2100,
-                        "fill_volume": 2000,
-                        "fill_concentration": 2.5,
-                        "uf": 100
-                    },
-                    {
-                        "exchange_no": 2,
-                        "exchange_time": "12:00",
-                        "drain_volume": 2050,
-                        "fill_volume": 2000,
-                        "fill_concentration": 2.5,
-                        "uf": 50
-                    }
-                ]
+                "total_uf": 150 # total_uf는 환자 수기 입력으로 '나중에' 입력해도 되므로 Optional
             }
         }
     )
-    record_date: str = Field(..., description="YYYY-MM-DD")
+    record_date: date = Field(..., description="YYYY-MM-DD")
     record_dw: DayWeekKR = Field(..., description="요일(월~일)")
-    weight: float = Field(..., ge=20.0, le=300.0)
-    systolic: int = Field(..., ge=70, le=240)
-    diastolic: int = Field(..., ge=40, le=160)
-    fasting_glucose: int = Field(..., ge=40, le=600)
-    urine_count: int = Field(..., ge=0, le=50)
-    turbidity: Turbidity
+    weight: Optional[float] = Field(None, ge=20.0, le=300.0)
+    systolic: Optional[int] = Field(None, ge=70, le=240)
+    diastolic: Optional[int] = Field(None, ge=40, le=160)
+    fasting_glucose: Optional[int] = Field(None, ge=40, le=600)
+    urine_count: Optional[int] = Field(None, ge=0, le=50)
+    turbidity: Optional[Turbidity] = None
     notes: Optional[str] = Field(None, max_length=2000)
-    total_uf: int = Field(..., ge=0, le=1000)
-    # 회차들 함께 생성 가능
-    exchanges: Annotated[list[RecordExchangeCreate], Field(default_factory=list)]
+    total_uf: Optional[int] = Field(None, ge=-5000, le=5000)
 
-
-class RecordPatch(ORMBase):
+# 공통 정보 수정 스키마
+class RecordCommonPatch(ORMBase):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
                 "weight": 61.2,
                 "turbidity": "있음",
-                "notes": "복막액 약간 혼탁, 통증 없음"
+                "notes": "복막액 약간 혼탁, 통증 없음",
+                "total_uf": 600
             }
         }
     )
-    record_date: Optional[str] = None
+    record_date: Optional[date] = None
     record_dw: Optional[DayWeekKR] = None
     weight: Optional[float] = Field(None, ge=20.0, le=300.0)
     systolic: Optional[int] = Field(None, ge=70, le=240)
@@ -131,18 +113,4 @@ class RecordPatch(ORMBase):
     urine_count: Optional[int] = Field(None, ge=0, le=50)
     turbidity: Optional[Turbidity] = None
     notes: Optional[str] = Field(None, max_length=2000)
-
-
-class RecordRead(ORMBase):
-    id: int
-    record_date: str
-    record_dw: DayWeekKR
-    weight: float
-    systolic: int
-    diastolic: int
-    fasting_glucose: int
-    urine_count: int
-    turbidity: Turbidity
-    notes: str
-    total_uf: int
-    exchanges: List[RecordExchangeRead]
+    total_uf: Optional[int] = Field(None, ge=-5000, le=5000)

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -1,20 +1,18 @@
 import re
 from datetime import time as dtime, date
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 from fastapi import HTTPException
 
 from app.db_models.record import Record
-
 from app.db_models.record_exchange import RecordExchange
-
 
 # 공통 유틸
 def vrng(cond: bool, msg: str):
     if not cond:
         raise HTTPException(status_code=400, detail=msg)
 
-# 시간 형식 검증
+# "HH:MM" 파싱
 def parse_time(s: str) -> dtime:
     s = (s or "").strip().replace("시", ":").replace(".", ":")
     m = re.match(r"^\s*(\d{1,2})\s*:\s*(\d{2})\s*$", s)
@@ -25,14 +23,7 @@ def parse_time(s: str) -> dtime:
         raise ValueError("시간 범위 오류(0~23시, 0~59분)")
     return dtime(hour=hh, minute=mm)
 
-
-# 날짜 형식 변환
-def _format_date_kr(d: Optional[date]) -> str:
-    if not d:
-        return ""
-    return f"{d.year}년 {d.month}월 {d.day}일"
-
-# dict 형식으로 변환
+# 직렬화(dict)
 def ex_to_dict(e: RecordExchange) -> Dict[str, Any]:
     return {
         "id": e.id,
@@ -44,11 +35,10 @@ def ex_to_dict(e: RecordExchange) -> Dict[str, Any]:
         "uf": e.uf
     }
 
-# dict 형식으로 변환
 def rec_to_dict(r: Record) -> Dict[str, Any]:
     return {
         "id": r.id,
-        "record_date": r.record_date,
+        "record_date": r.record_date.strftime("%Y-%m-%d") if isinstance(r.record_date, date) else r.record_date,
         "record_dw": r.record_dw,
         "weight": r.weight,
         "systolic": r.systolic,
@@ -57,14 +47,27 @@ def rec_to_dict(r: Record) -> Dict[str, Any]:
         "urine_count": r.urine_count,
         "turbidity": r.turbidity,
         "notes": r.notes,
-
         "total_uf": r.total_uf,
         "exchanges": [ex_to_dict(e) for e in (r.exchanges or [])],
     }
 
-
-# 공통 수정사항 적용
+# 공통 정보 필드 패치
 def apply_record_patch(rec: Record, p: Dict[str, Any]) -> None:
+    if "record_date" in p and p["record_date"] is not None:
+        rd = p["record_date"]
+        if isinstance(rd, str):
+            try:
+                rec.record_date = date.fromisoformat(rd)
+            except Exception:
+                raise HTTPException(status_code=400, detail=f"record_date 형식 오류: {rd}")
+        elif isinstance(rd, date):
+            rec.record_date = rd
+
+    if "record_dw" in p and p["record_dw"] is not None:
+        dw = str(p["record_dw"])
+        vrng(dw in {"월", "화", "수", "목", "금", "토", "일"}, "record_dw는 월~일 중 하나여야 합니다.")
+        rec.record_dw = dw
+
     if "weight" in p and p["weight"] is not None:
         w = float(p["weight"])
         vrng(20.0 <= w <= 300.0, "체중 20~300kg")
@@ -97,14 +100,22 @@ def apply_record_patch(rec: Record, p: Dict[str, Any]) -> None:
     if "notes" in p and p["notes"] is not None:
         rec.notes = str(p["notes"])[:2000]
 
+    if "total_uf" in p and p["total_uf"] is not None:
+        # 합계는 음수도 가능하게 허용
+        try:
+            tu = int(p["total_uf"])
+        except Exception:
+            raise HTTPException(status_code=400, detail="total_uf는 정수여야 합니다.")
+        vrng(-5000 <= tu <= 5000, "total_uf 범위 오류(±5000)")
+        rec.total_uf = tu
 
-# 패치 적용: 회차(개별) 수정사항 적용
+# 회차 정보 upsert
 def upsert_exchange(rec: Record, p: Dict[str, Any]) -> RecordExchange:
     vrng("exchange_no" in p and p["exchange_no"] is not None, "회차(개별)에는 exchange_no가 필요합니다.")
     ex_no = int(p["exchange_no"])
     vrng(1 <= ex_no <= 12, "회차는 1~12 범위")
 
-    # 이미 로딩된 관계에서 탐색
+    # 기존 찾기
     target = None
     if rec.exchanges:
         for e in rec.exchanges:
@@ -112,12 +123,11 @@ def upsert_exchange(rec: Record, p: Dict[str, Any]) -> RecordExchange:
                 target = e
                 break
 
-    # 없으면 새로 만듦
+    # 없으면 신규
     if target is None:
         target = RecordExchange(exchange_no=ex_no)
         rec.exchanges.append(target)
 
-    # 필드 적용
     if "exchange_time" in p and p["exchange_time"] is not None:
         target.exchange_time = parse_time(p["exchange_time"])
 
@@ -138,42 +148,7 @@ def upsert_exchange(rec: Record, p: Dict[str, Any]) -> RecordExchange:
 
     if "uf" in p and p["uf"] is not None:
         uf = int(p["uf"])
-        vrng(0 <= uf <= 6000, "제수량 -500~500 g")
+        vrng(-500 <= uf <= 500, "제수량 -500~500 g")
         target.uf = uf
 
     return target
-
-# 일일 + 회차 패치 적용
-def apply_patch(rec: Record, p: Dict[str, Any]) -> None:
-    if not isinstance(p, dict):
-        raise HTTPException(status_code=400, detail="patch payload는 dict여야 합니다.")
-
-    # 1) 일일 공통 먼저 적용
-    apply_record_patch(rec, p)
-
-    # 2-A) 회차 배치 업데이트: {"exchanges": [ {...}, {...} ]}
-    if "exchanges" in p and p["exchanges"] is not None:
-        ex_list = p["exchanges"]
-        if not isinstance(ex_list, list):
-            raise HTTPException(status_code=400, detail="exchanges는 리스트여야 합니다.")
-
-        seen = set()
-        for ex in ex_list:
-            if not isinstance(ex, dict):
-                raise HTTPException(status_code=400, detail="exchanges 항목은 dict여야 합니다.")
-            if "exchange_no" not in ex or ex["exchange_no"] is None:
-                raise HTTPException(status_code=400, detail="각 회차에는 exchange_no가 필요합니다.")
-
-            ex_no = int(ex["exchange_no"])
-            if ex_no in seen:
-                raise HTTPException(status_code=400, detail=f"회차 번호 중복: {ex_no}")
-            seen.add(ex_no)
-
-            # 각 회차 패치를 upsert
-            upsert_exchange(rec, ex)
-
-    # 2-B) 회차 단건 업데이트: 단일 dict에 회차 관련 키가 들어온 경우
-    else:
-        exchange_keys = {"exchange_no", "exchange_time", "drain_volume", "fill_volume", "fill_concentration", "uf"}
-        if any(k in p for k in exchange_keys):
-            upsert_exchange(rec, p)

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -23,7 +23,7 @@ def parse_time(s: str) -> dtime:
         raise ValueError("시간 범위 오류(0~23시, 0~59분)")
     return dtime(hour=hh, minute=mm)
 
-# 직렬화(dict)
+# 회차 정보 직렬화(dict)
 def ex_to_dict(e: RecordExchange) -> Dict[str, Any]:
     return {
         "id": e.id,
@@ -35,6 +35,7 @@ def ex_to_dict(e: RecordExchange) -> Dict[str, Any]:
         "uf": e.uf
     }
 
+# 공통 정보 직렬화(dict)
 def rec_to_dict(r: Record) -> Dict[str, Any]:
     return {
         "id": r.id,
@@ -101,7 +102,6 @@ def apply_record_patch(rec: Record, p: Dict[str, Any]) -> None:
         rec.notes = str(p["notes"])[:2000]
 
     if "total_uf" in p and p["total_uf"] is not None:
-        # 합계는 음수도 가능하게 허용
         try:
             tu = int(p["total_uf"])
         except Exception:


### PR DESCRIPTION
## 📝 작업 내용
에라이 다른 브랜치에서 작업하는 실수를 하다니..

api 연동하면서 문제 있으면 수정해야 할듯! + 디자인 변동 가능성
(기존) 기록 수기 작성 api, 기록 수정 api, 기록 조회 api
(변경) 태그로 분리
<img width="877" height="890" alt="image" src="https://github.com/user-attachments/assets/d2dff630-f0e2-49ae-9066-26a7ee784462" />


회차 정보 생성 시 기록 id 값을 주면 해당 record와 매핑되어 회차 데이터 생성
제수량 합계(total_uf)는 공통 정보 입력 -> 회차별 데이터 입력 현재 구조로 진행된다면 처음에는 입력받지 않고, 회차별 기록 모아보기 화면 하단에 있는 공통 정보란에서 입력 or 수정할 수 있게 할 예정.
프레그먼트 순서에 대해 고민하는중..