### PR TITLE
[Refactor/#42] 제수량 합계 필드 null 허용

### DIFF
--- a/app/db_models/record.py
+++ b/app/db_models/record.py
@@ -25,7 +25,7 @@ class Record(Base, TimestampMixin):
     turbidity = Column(TurbidityEnum, nullable=False)  # 복막액 혼탁(없음/있음)
     notes = Column(Text, nullable=True) # 비고
 
-    total_uf = Column(Integer, nullable=False)  # 제수량 합계
+    total_uf = Column(Integer, nullable=True)  # 제수량 합계
 
     # 관계: 회차별 데이터
     exchanges = relationship(

--- a/app/models/recordSchemas.py
+++ b/app/models/recordSchemas.py
@@ -83,12 +83,12 @@ class RecordCommonCreate(ORMBase):
     )
     record_date: date = Field(..., description="YYYY-MM-DD")
     record_dw: DayWeekKR = Field(..., description="요일(월~일)")
-    weight: Optional[float] = Field(None, ge=20.0, le=300.0)
-    systolic: Optional[int] = Field(None, ge=70, le=240)
-    diastolic: Optional[int] = Field(None, ge=40, le=160)
-    fasting_glucose: Optional[int] = Field(None, ge=40, le=600)
-    urine_count: Optional[int] = Field(None, ge=0, le=50)
-    turbidity: Optional[Turbidity] = None
+    weight: float = Field(None, ge=20.0, le=300.0)
+    systolic: int = Field(None, ge=70, le=240)
+    diastolic: int = Field(None, ge=40, le=160)
+    fasting_glucose: int = Field(None, ge=40, le=600)
+    urine_count: int = Field(None, ge=0, le=50)
+    turbidity: Turbidity = None
     notes: Optional[str] = Field(None, max_length=2000)
     total_uf: Optional[int] = Field(None, ge=-5000, le=5000)
 


### PR DESCRIPTION
## 📝 작업 내용
제수량 합계 필드 null 허용 + 공통 정보 생성 시 optional 제거(비고, 제수량 합계 제외)

화면 구조 상, 공통 정보를 먼저 입력받고 회차 정보를 입력받게 되어있기 때문에
total_uf(제수량 합계) 필드를 처음에 null로 전달하고 기록 모아보기 화면에서 입력받게 하였습니다.
그런데 그런 구조로 진행하면 total_uf를 끝까지 입력하지 않고 저장할 수 있기 때문에 구조에 대해 더 고민해봐야 할 것 같습니다...
일단은 null 허용으로 진행하겠습니다.