### PR TITLE
[REFACTOR/#46] 제수량 합계 필수 입력

### DIFF
--- a/app/db_models/record.py
+++ b/app/db_models/record.py
@@ -25,7 +25,7 @@ class Record(Base, TimestampMixin):
     turbidity = Column(TurbidityEnum, nullable=False)  # 복막액 혼탁(없음/있음)
     notes = Column(Text, nullable=True) # 비고
 
-    total_uf = Column(Integer, nullable=True)  # 제수량 합계
+    total_uf = Column(Integer, nullable=False)  # 제수량 합계
 
     # 관계: 회차별 데이터
     exchanges = relationship(

--- a/app/models/recordSchemas.py
+++ b/app/models/recordSchemas.py
@@ -83,14 +83,14 @@ class RecordCommonCreate(ORMBase):
     )
     record_date: date = Field(..., description="YYYY-MM-DD")
     record_dw: DayWeekKR = Field(..., description="요일(월~일)")
-    weight: float = Field(None, ge=20.0, le=300.0)
-    systolic: int = Field(None, ge=70, le=240)
-    diastolic: int = Field(None, ge=40, le=160)
-    fasting_glucose: int = Field(None, ge=40, le=600)
-    urine_count: int = Field(None, ge=0, le=50)
-    turbidity: Turbidity = None
+    weight: float = Field(..., ge=20.0, le=300.0)
+    systolic: int = Field(..., ge=70, le=240)
+    diastolic: int = Field(..., ge=40, le=160)
+    fasting_glucose: int = Field(..., ge=40, le=600)
+    urine_count: int = Field(..., ge=0, le=50)
+    turbidity: Turbidity = Field(..., description="혼탁도(없음/있음)")
     notes: Optional[str] = Field(None, max_length=2000)
-    total_uf: int = Field(None, ge=-5000, le=5000)
+    total_uf: int = Field(..., ge=-5000, le=5000)
 
 # 공통 정보 수정 스키마
 class RecordCommonPatch(ORMBase):

--- a/app/models/recordSchemas.py
+++ b/app/models/recordSchemas.py
@@ -77,7 +77,7 @@ class RecordCommonCreate(ORMBase):
                 "urine_count": 6,
                 "turbidity": "없음",
                 "notes": "환자의 상태 양호",
-                "total_uf": 150 # total_uf는 현재 구조 상 나중 입력
+                "total_uf": 150
             }
         }
     )
@@ -90,7 +90,7 @@ class RecordCommonCreate(ORMBase):
     urine_count: int = Field(None, ge=0, le=50)
     turbidity: Turbidity = None
     notes: Optional[str] = Field(None, max_length=2000)
-    total_uf: Optional[int] = Field(None, ge=-5000, le=5000)
+    total_uf: int = Field(None, ge=-5000, le=5000)
 
 # 공통 정보 수정 스키마
 class RecordCommonPatch(ORMBase):


### PR DESCRIPTION
## 📝 작업 내용
제수량 합계를 not null로 변경하였으며, 공통 정보 입력 화면에서 제수량 합계 입력란을 추가할 예정입니다.
화면 구조에 대해서는 아직 고민중입니다..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **변경사항**
  * 레코드 생성 시 total_uf가 필수로 변경되었습니다(값 범위: -5000 ~ 5000).
  * weight, systolic, diastolic, fasting_glucose, urine_count, turbidity 필드가 더 이상 선택 항목이 아니며 생성 시 반드시 제공해야 합니다.
  * turbidity에 대한 설명(혼탁도: 없음/있음)이 스키마에 명시되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->