### PR TITLE
[Refactor/#52] upsert 로직 제거

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,5 +1,6 @@
 from fastapi import Depends, HTTPException, APIRouter, UploadFile, File, Response
 from sqlalchemy import asc
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 from datetime import date as _date
 
@@ -11,9 +12,9 @@ from app.db_models.record import Record
 from app.db_models.record_exchange import RecordExchange
 
 from app.models.recordSchemas import RecordCommonPatch, RecordCommonCreate, RecordExchangeCreate, RecordExchangePatch
-from app.services.ocrService import OcrError, ocr_bytes_to_pdrecord_json, save_pdrecord_json
+from app.services.ocrService import OcrError, ocr_bytes_to_pdrecord_json, save_pdrecord_json, _record_to_dict
 from app.services.recordService import rec_to_dict, apply_record_patch, ex_to_dict, create_exchange, \
-    patch_exchange
+    patch_exchange, create_record_common
 
 router = APIRouter()
 
@@ -23,30 +24,19 @@ router = APIRouter()
     "/api/v1/records",
     tags=["복막투석기록-공통"],
     summary="공통 정보 생성",
-    description="회차 없이 공통 정보만 생성합니다.",
+    description="회차 없이 공통 정보만 생성합니다. 같은 날짜가 이미 있으면 409를 반환합니다.",
     status_code=204,
     responses={204: {"description": "성공입니다"}},
 )
-def create_record_common(payload: RecordCommonCreate, db: Session = Depends(get_db)):
-    d = payload.record_date or _date.today()
+def create_record_common_route(payload: RecordCommonCreate, db: Session = Depends(get_db)):
+    p = payload.model_dump(exclude_unset=True)
+    try:
+        create_record_common(db, p, unique_by_date=True)
+        return Response(status_code=204)
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="해당 날짜의 기록이 이미 존재합니다.")
 
-    rec = Record(
-        record_date=d,
-        record_dw=payload.record_dw,
-        weight=payload.weight,
-        systolic=payload.systolic,
-        diastolic=payload.diastolic,
-        fasting_glucose=payload.fasting_glucose,
-        urine_count=payload.urine_count,
-        turbidity=payload.turbidity,
-        notes=payload.notes,
-        total_uf=payload.total_uf,
-    )
-
-    db.add(rec)
-    db.commit()
-    db.refresh(rec)
-    return Response(status_code=204)
 
 # 복막투석기록 공통 정보 수정 api
 @router.patch(
@@ -63,6 +53,21 @@ def patch_record_common(rec_id: int, payload: RecordCommonPatch, db: Session = D
         raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
 
     patch = payload.model_dump(exclude_unset=True)
+
+    # record_date가 변경되는 경우, 동일 날짜의 다른 레코드가 있는지 검사
+    if "record_date" in patch and patch["record_date"] is not None:
+        new_date = patch["record_date"]
+        if isinstance(new_date, str):
+            new_date = _date.fromisoformat(new_date)
+        if new_date != rec.record_date:
+            exists = (
+                db.query(Record.id)
+                .filter(Record.record_date == new_date, Record.id != rec.id)
+                .first()
+            )
+            if exists:
+                raise HTTPException(status_code=409, detail=f"{new_date.isoformat()} 기록이 이미 존재합니다.")
+
     apply_record_patch(rec, patch)
 
     db.add(rec)

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -11,8 +11,9 @@ from app.db_models.record import Record
 from app.db_models.record_exchange import RecordExchange
 
 from app.models.recordSchemas import RecordCommonPatch, RecordCommonCreate, RecordExchangeCreate, RecordExchangePatch
-from app.services.ocrService import OcrError, ocr_bytes_to_pdrecord_json, save_pdrecord_json, _record_to_dict
-from app.services.recordService import rec_to_dict, apply_record_patch, upsert_exchange, ex_to_dict
+from app.services.ocrService import OcrError, ocr_bytes_to_pdrecord_json, save_pdrecord_json
+from app.services.recordService import rec_to_dict, apply_record_patch, ex_to_dict, create_exchange, \
+    patch_exchange
 
 router = APIRouter()
 
@@ -39,7 +40,7 @@ def create_record_common(payload: RecordCommonCreate, db: Session = Depends(get_
         urine_count=payload.urine_count,
         turbidity=payload.turbidity,
         notes=payload.notes,
-        total_uf=payload.total_uf, # 합계는 선택 입력(후입력 가능)
+        total_uf=payload.total_uf,
     )
 
     db.add(rec)
@@ -84,7 +85,7 @@ def upsert_record_exchange(rec_id: int, payload: RecordExchangeCreate, db: Sessi
         raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
 
     p = payload.model_dump()
-    upsert_exchange(rec, p)
+    create_exchange(rec, p)
 
     db.add(rec)
     db.commit()
@@ -108,7 +109,7 @@ def patch_record_exchange(rec_id: int, exchange_no: int, payload: RecordExchange
     p = payload.model_dump(exclude_unset=True)
     p["exchange_no"] = p.get("exchange_no", exchange_no)
 
-    upsert_exchange(rec, p)
+    patch_exchange(rec, p)
 
     db.add(rec)
     db.commit()
@@ -193,6 +194,8 @@ def ocr_and_save(file: UploadFile = File(...), db: Session = Depends(get_db)):
 
     except OcrError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
     except ValueError as e:
         # save_pdrecord_json 내부 검증(필수값, 형식) 에러
         raise HTTPException(status_code=422, detail=str(e))

--- a/app/services/ocrService.py
+++ b/app/services/ocrService.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 from google import genai
 from base64 import b64encode
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.db_models.record import Record
@@ -223,8 +224,15 @@ def save_pdrecord_json(data: Dict[str, Any], db: Session) -> Record:
             )
         )
 
-    db.add_all(rows)
-    db.commit()
+    try:
+        db.add_all(rows)
+        db.commit()
+    except IntegrityError as e:
+        db.rollback()
+        raise HTTPException(
+                status_code=409,
+                detail = f"{record_date.isoformat()} 해당 기록이 이미 존재합니다.",
+        ) from e
     db.refresh(record)
     return record
 

--- a/app/services/ocrService.py
+++ b/app/services/ocrService.py
@@ -195,8 +195,6 @@ def save_pdrecord_json(data: Dict[str, Any], db: Session) -> Record:
         notes=notes,
         total_uf=total_uf,
     )
-    db.add(record)
-    db.flush()  # record.id 확보
 
     # 교환회차
     exchanges: List[Dict[str, Any]] = data.get("exchanges") or []
@@ -225,16 +223,21 @@ def save_pdrecord_json(data: Dict[str, Any], db: Session) -> Record:
         )
 
     try:
+        db.add(record)
+        db.flush()  # record.id 확보
         db.add_all(rows)
         db.commit()
     except IntegrityError as e:
         db.rollback()
-        raise HTTPException(
-                status_code=409,
-                detail = f"{record_date.isoformat()} 해당 기록이 이미 존재합니다.",
-        ) from e
-    db.refresh(record)
-    return record
+        # record_date 중복인 경우에만 명확한 메시지 제공
+        if "record_date" in str(e.orig):
+            detail = f"{record_date.isoformat()} 해당 기록이 이미 존재합니다."
+        else:
+            detail = "데이터 무결성 제약 조건을 위반했습니다."
+    raise HTTPException(
+        status_code=409,
+        detail = detail,
+    ) from e
 
 
 # Record 객체를 응답 JSON으로 직렬화

--- a/app/services/ocrService.py
+++ b/app/services/ocrService.py
@@ -234,10 +234,13 @@ def save_pdrecord_json(data: Dict[str, Any], db: Session) -> Record:
             detail = f"{record_date.isoformat()} 해당 기록이 이미 존재합니다."
         else:
             detail = "데이터 무결성 제약 조건을 위반했습니다."
-    raise HTTPException(
-        status_code=409,
-        detail = detail,
-    ) from e
+        raise HTTPException(
+            status_code=409,
+            detail = detail,
+        ) from e
+
+    db.refresh(record)
+    return record
 
 
 # Record 객체를 응답 JSON으로 직렬화

--- a/app/services/ocrService.py
+++ b/app/services/ocrService.py
@@ -4,6 +4,7 @@ from datetime import date, datetime, time
 from typing import Optional, Dict, Any, List
 
 from dotenv import load_dotenv
+from fastapi import HTTPException
 from google import genai
 from base64 import b64encode
 
@@ -150,9 +151,8 @@ def _norm_dayweek(dw: Optional[str], d: date) -> str:
     return WEEK_KR[d.weekday()]
 
 
-# OCR 구조화 JSON을 받아 db에 저장 (단, 같은 기록 날짜의 레코드가 있으면 기존 데이터 삭제 후 재삽입 -> 추후에 기존 데이터는 유지하도록 로직 변경?)
+# OCR 구조화 JSON을 받아 db에 저장 (중복 날짜는 409 반환)
 def save_pdrecord_json(data: Dict[str, Any], db: Session) -> Record:
-
     record_date = _parse_date(data.get("record_date"))
     record_dw = _norm_dayweek(data.get("record_dw"), record_date)
 
@@ -163,7 +163,6 @@ def save_pdrecord_json(data: Dict[str, Any], db: Session) -> Record:
     fasting_glucose = _to_int_required(data.get("fasting_glucose"), "fasting_glucose")
     urine_count = _to_int_required(data.get("urine_count"), "urine_count")
 
-    # 추후에 turbidity_conflict, turbidity_marked 등을 추가하여 환자가 2개를 표시한 경우 / 표시하지 않은 경우 예외 처리
     turbidity = data.get("turbidity")
     if turbidity not in ("없음", "있음"):
         raise ValueError("turbidity는 '없음' 또는 '있음'이어야 합니다.")
@@ -171,48 +170,37 @@ def save_pdrecord_json(data: Dict[str, Any], db: Session) -> Record:
     notes = data.get("notes")
     total_uf = _to_int_required(data.get("total_uf"), "total_uf")
 
-    # 기존 레코드 조회
-    record = (
+    # 동일 날짜 존재 여부 체크
+    existing = (
         db.query(Record)
         .filter(Record.record_date == record_date)
         .one_or_none()
     )
-
-    # upsert
-    if record is None:
-        record = Record(
-            record_date=record_date,
-            record_dw=record_dw,
-            weight=weight,
-            systolic=systolic,
-            diastolic=diastolic,
-            fasting_glucose=fasting_glucose,
-            urine_count=urine_count,
-            turbidity=turbidity,
-            notes=notes,
-            total_uf=total_uf,
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"{record_date.isoformat()} 해당 기록이 이미 존재합니다."
         )
-        db.add(record)
-        db.flush() # record.id 확보
 
-    else:
-        record.record_dw = record_dw
-        record.weight = weight
-        record.systolic = systolic
-        record.diastolic = diastolic
-        record.fasting_glucose = fasting_glucose
-        record.urine_count = urine_count
-        record.turbidity = turbidity
-        record.notes = notes
-        record.total_uf = total_uf
-
-        db.query(RecordExchange).filter(RecordExchange.record_id == record.id).delete() # 기존 데이터 삭제
+    record = Record(
+        record_date=record_date,
+        record_dw=record_dw,
+        weight=weight,
+        systolic=systolic,
+        diastolic=diastolic,
+        fasting_glucose=fasting_glucose,
+        urine_count=urine_count,
+        turbidity=turbidity,
+        notes=notes,
+        total_uf=total_uf,
+    )
+    db.add(record)
+    db.flush()  # record.id 확보
 
     # 교환회차
     exchanges: List[Dict[str, Any]] = data.get("exchanges") or []
     if not exchanges:
         raise ValueError("exchanges가 비어 있습니다.")
-        pass
 
     rows: List[RecordExchange] = []
     for ex in exchanges:
@@ -235,41 +223,7 @@ def save_pdrecord_json(data: Dict[str, Any], db: Session) -> Record:
             )
         )
 
-    if rows:
-        db.add_all(rows)
-
+    db.add_all(rows)
     db.commit()
     db.refresh(record)
     return record
-
-
-# Record 객체를 응답 JSON으로 직렬화
-def _record_to_dict(rec) -> dict:
-    def _t(t):
-        return t.strftime("%H:%M") if t else None
-
-    return {
-        "id": rec.id,
-        "record_date": rec.record_date.isoformat(),
-        "record_dw": rec.record_dw,
-        "weight": rec.weight,
-        "systolic": rec.systolic,
-        "diastolic": rec.diastolic,
-        "fasting_glucose": rec.fasting_glucose,
-        "urine_count": rec.urine_count,
-        "turbidity": rec.turbidity,
-        "notes": rec.notes,
-        "total_uf": rec.total_uf,
-        "exchanges": [
-            {
-                "id": ex.id,
-                "exchange_no": ex.exchange_no,
-                "exchange_time": _t(ex.exchange_time),
-                "drain_volume": ex.drain_volume,
-                "fill_volume": ex.fill_volume,
-                "fill_concentration": ex.fill_concentration,
-                "uf": ex.uf,
-            }
-            for ex in (rec.exchanges or [])
-        ],
-    }

--- a/app/services/ocrService.py
+++ b/app/services/ocrService.py
@@ -227,3 +227,35 @@ def save_pdrecord_json(data: Dict[str, Any], db: Session) -> Record:
     db.commit()
     db.refresh(record)
     return record
+
+
+# Record 객체를 응답 JSON으로 직렬화
+def _record_to_dict(rec) -> dict:
+    def _t(t):
+        return t.strftime("%H:%M") if t else None
+
+    return {
+        "id": rec.id,
+        "record_date": rec.record_date.isoformat(),
+        "record_dw": rec.record_dw,
+        "weight": rec.weight,
+        "systolic": rec.systolic,
+        "diastolic": rec.diastolic,
+        "fasting_glucose": rec.fasting_glucose,
+        "urine_count": rec.urine_count,
+        "turbidity": rec.turbidity,
+        "notes": rec.notes,
+        "total_uf": rec.total_uf,
+        "exchanges": [
+            {
+                "id": ex.id,
+                "exchange_no": ex.exchange_no,
+                "exchange_time": _t(ex.exchange_time),
+                "drain_volume": ex.drain_volume,
+                "fill_volume": ex.fill_volume,
+                "fill_concentration": ex.fill_concentration,
+                "uf": ex.uf,
+            }
+            for ex in (rec.exchanges or [])
+        ],
+    }

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -1,18 +1,20 @@
 import re
 from datetime import time as dtime, date
-from typing import Dict, Any
+from typing import Dict, Any, Optional  # Optional 추가
 
 from fastapi import HTTPException
 
 from app.db_models.record import Record
 from app.db_models.record_exchange import RecordExchange
 
-# 공통 유틸
+# =========================
+# 공통 유틸 / 파서
+# =========================
+
 def vrng(cond: bool, msg: str):
     if not cond:
         raise HTTPException(status_code=400, detail=msg)
 
-# "HH:MM" 파싱
 def parse_time(s: str) -> dtime:
     s = (s or "").strip().replace("시", ":").replace(".", ":")
     m = re.match(r"^\s*(\d{1,2})\s*:\s*(\d{2})\s*$", s)
@@ -23,7 +25,41 @@ def parse_time(s: str) -> dtime:
         raise ValueError("시간 범위 오류(0~23시, 0~59분)")
     return dtime(hour=hh, minute=mm)
 
-# 회차 정보 직렬화(dict)
+# 범용: payload에 키가 있고 값이 None이 아닐 때만 fn을 적용해 target.attr에 대입
+def _apply_if_present(
+    target: Any,
+    payload: Dict[str, Any],
+    key: str,
+    fn,  # value -> cast/validate -> return
+    attr: Optional[str] = None
+):
+    if key in payload and payload[key] is not None:
+        value = fn(payload[key])
+        setattr(target, attr or key, value)
+
+# =========================
+# 검증 헬퍼 메소드
+# =========================
+def _as_int_in(v: Any, lo: int, hi: int, label: str) -> int:
+    try:
+        iv = int(v)
+    except Exception:
+        raise HTTPException(status_code=400, detail=f"{label}는 정수여야 합니다.")
+    vrng(lo <= iv <= hi, f"{label} 범위({lo}~{hi})")
+    return iv
+
+def _as_float_in(v: Any, lo: float, hi: float, label: str) -> float:
+    try:
+        fv = float(v)
+    except Exception:
+        raise HTTPException(status_code=400, detail=f"{label}는 실수여야 합니다.")
+    vrng(lo <= fv <= hi, f"{label} 범위({lo}~{hi})")
+    return fv
+
+# =========================
+# 직렬화
+# =========================
+
 def ex_to_dict(e: RecordExchange) -> Dict[str, Any]:
     return {
         "id": e.id,
@@ -35,7 +71,6 @@ def ex_to_dict(e: RecordExchange) -> Dict[str, Any]:
         "uf": e.uf
     }
 
-# 공통 정보 직렬화(dict)
 def rec_to_dict(r: Record) -> Dict[str, Any]:
     return {
         "id": r.id,
@@ -52,7 +87,10 @@ def rec_to_dict(r: Record) -> Dict[str, Any]:
         "exchanges": [ex_to_dict(e) for e in (r.exchanges or [])],
     }
 
-# 공통 정보 필드 패치
+# =========================
+# 공통 정보 패치
+# =========================
+
 def apply_record_patch(rec: Record, p: Dict[str, Any]) -> None:
     if "record_date" in p and p["record_date"] is not None:
         rd = p["record_date"]
@@ -70,29 +108,19 @@ def apply_record_patch(rec: Record, p: Dict[str, Any]) -> None:
         rec.record_dw = dw
 
     if "weight" in p and p["weight"] is not None:
-        w = float(p["weight"])
-        vrng(20.0 <= w <= 300.0, "체중 20~300kg")
-        rec.weight = round(w, 1)
+        rec.weight = round(_as_float_in(p["weight"], 20.0, 300.0, "체중(kg)"), 1)
 
     if "systolic" in p and p["systolic"] is not None:
-        s = int(p["systolic"])
-        vrng(70 <= s <= 240, "수축기 70~240")
-        rec.systolic = s
+        rec.systolic = _as_int_in(p["systolic"], 70, 240, "수축기")
 
     if "diastolic" in p and p["diastolic"] is not None:
-        d = int(p["diastolic"])
-        vrng(40 <= d <= 160, "이완기 40~160")
-        rec.diastolic = d
+        rec.diastolic = _as_int_in(p["diastolic"], 40, 160, "이완기")
 
     if "fasting_glucose" in p and p["fasting_glucose"] is not None:
-        g = int(p["fasting_glucose"])
-        vrng(40 <= g <= 600, "공복혈당 40~600 mg/dL")
-        rec.fasting_glucose = g
+        rec.fasting_glucose = _as_int_in(p["fasting_glucose"], 40, 600, "공복혈당")
 
     if "urine_count" in p and p["urine_count"] is not None:
-        u = int(p["urine_count"])
-        vrng(0 <= u <= 50, "소변 횟수 0~50회")
-        rec.urine_count = u
+        rec.urine_count = _as_int_in(p["urine_count"], 0, 50, "소변 횟수")
 
     if "turbidity" in p and p["turbidity"] is not None:
         vrng(p["turbidity"] in {"없음", "있음"}, "turbidity 값 오류(없음/있음)")
@@ -102,53 +130,50 @@ def apply_record_patch(rec: Record, p: Dict[str, Any]) -> None:
         rec.notes = str(p["notes"])[:2000]
 
     if "total_uf" in p and p["total_uf"] is not None:
-        try:
-            tu = int(p["total_uf"])
-        except Exception:
-            raise HTTPException(status_code=400, detail="total_uf는 정수여야 합니다.")
-        vrng(-5000 <= tu <= 5000, "total_uf 범위 오류(±5000)")
-        rec.total_uf = tu
+        rec.total_uf = _as_int_in(p["total_uf"], -5000, 5000, "total_uf")
 
-# 회차 정보 upsert
-def upsert_exchange(rec: Record, p: Dict[str, Any]) -> RecordExchange:
+# =========================
+# 회차 공통 처리
+# =========================
+
+def _require_exchange_no(p: Dict[str, Any]) -> int:
     vrng("exchange_no" in p and p["exchange_no"] is not None, "회차(개별)에는 exchange_no가 필요합니다.")
     ex_no = int(p["exchange_no"])
     vrng(1 <= ex_no <= 12, "회차는 1~12 범위")
+    return ex_no
 
-    # 기존 찾기
-    target = None
-    if rec.exchanges:
-        for e in rec.exchanges:
-            if e.exchange_no == ex_no:
-                target = e
-                break
+def _apply_exchange_fields(target: RecordExchange, p: Dict[str, Any]) -> None:
+    _apply_if_present(target, p, "exchange_time", lambda v: parse_time(v))
+    _apply_if_present(target, p, "drain_volume", lambda v: _as_int_in(v, 0, 6000, "배액량"))
+    _apply_if_present(target, p, "fill_volume",  lambda v: _as_int_in(v, 0, 6000, "주입액 중량"))
+    _apply_if_present(target, p, "fill_concentration", lambda v: _as_float_in(v, 0.0, 100.0, "주입액 농도(%)"))
+    _apply_if_present(target, p, "uf", lambda v: _as_int_in(v, -500, 500, "제수량"))
 
-    # 없으면 신규
+def find_exchange(rec: Record, exchange_no: int) -> Optional[RecordExchange]:
+    if not rec.exchanges:
+        return None
+    for e in rec.exchanges:
+        if e.exchange_no == exchange_no:
+            return e
+    return None
+
+# 존재하는 회차만 수정
+def patch_exchange(rec: Record, p: Dict[str, Any]) -> RecordExchange:
+    ex_no = _require_exchange_no(p)
+    target = find_exchange(rec, ex_no)
     if target is None:
-        target = RecordExchange(exchange_no=ex_no)
-        rec.exchanges.append(target)
+        raise HTTPException(status_code=404, detail=f"{ex_no}회차가 존재하지 않습니다.")
+    _apply_exchange_fields(target, p)
+    return target
 
-    if "exchange_time" in p and p["exchange_time"] is not None:
-        target.exchange_time = parse_time(p["exchange_time"])
+def create_exchange(rec: Record, p: Dict[str, Any]) -> RecordExchange:
+    ex_no = _require_exchange_no(p)
+    if find_exchange(rec, ex_no) is not None:
+        raise HTTPException(status_code=409, detail=f"{ex_no}회차가 이미 존재합니다.")
 
-    if "drain_volume" in p and p["drain_volume"] is not None:
-        dv = int(p["drain_volume"])
-        vrng(0 <= dv <= 6000, "배액량 0~6000 g")
-        target.drain_volume = dv
+    target = RecordExchange(exchange_no=ex_no)
+    _apply_exchange_fields(target, p)
 
-    if "fill_volume" in p and p["fill_volume"] is not None:
-        fv = int(p["fill_volume"])
-        vrng(0 <= fv <= 6000, "주입액 중량 0~6000 g")
-        target.fill_volume = fv
-
-    if "fill_concentration" in p and p["fill_concentration"] is not None:
-        fc = float(p["fill_concentration"])
-        vrng(0 <= fc <= 100, "주입액 농도 0~100 %")
-        target.fill_concentration = fc
-
-    if "uf" in p and p["uf"] is not None:
-        uf = int(p["uf"])
-        vrng(-500 <= uf <= 500, "제수량 -500~500 g")
-        target.uf = uf
-
+    rec.exchanges = (rec.exchanges or [])
+    rec.exchanges.append(target)
     return target

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -1,8 +1,10 @@
 import re
 from datetime import time as dtime, date
-from typing import Dict, Any, Optional  # Optional 추가
+from typing import Dict, Any, Optional
+from datetime import date as _date
 
 from fastapi import HTTPException
+from sqlalchemy.orm import Session
 
 from app.db_models.record import Record
 from app.db_models.record_exchange import RecordExchange
@@ -25,7 +27,7 @@ def parse_time(s: str) -> dtime:
         raise ValueError("시간 범위 오류(0~23시, 0~59분)")
     return dtime(hour=hh, minute=mm)
 
-# 범용: payload에 키가 있고 값이 None이 아닐 때만 fn을 적용해 target.attr에 대입
+# payload에 키가 있고 값이 None이 아닐 때만 fn을 적용해 target.attr에 대입
 def _apply_if_present(
     target: Any,
     payload: Dict[str, Any],
@@ -87,10 +89,52 @@ def rec_to_dict(r: Record) -> Dict[str, Any]:
         "exchanges": [ex_to_dict(e) for e in (r.exchanges or [])],
     }
 
-# =========================
-# 공통 정보 패치
-# =========================
 
+# 필수 값 체크
+def _require_fields_for_create(rec: Record):
+    vrng(rec.record_date is not None, "record_date는 필수입니다.")
+    vrng(rec.record_dw in {"월","화","수","목","금","토","일"}, "record_dw는 월~일 중 하나여야 합니다.")
+    vrng(rec.weight is not None, "weight는 필수입니다.")
+    vrng(rec.systolic is not None, "systolic는 필수입니다.")
+    vrng(rec.diastolic is not None, "diastolic는 필수입니다.")
+    vrng(rec.fasting_glucose is not None, "fasting_glucose는 필수입니다.")
+    vrng(rec.urine_count is not None, "urine_count는 필수입니다.")
+    vrng(rec.turbidity in {"없음","있음"}, "turbidity는 '없음' 또는 '있음'이어야 합니다.")
+    vrng(rec.total_uf is not None, "total_uf는 필수입니다.")
+
+
+# 공통 정보 생성용 객체 빌더
+def create_record_common_obj(p: Dict[str, Any]) -> Record:
+    rec = Record()
+    # 날짜 미지정 시 오늘
+    if "record_date" not in p or p["record_date"] is None:
+        p = {**p, "record_date": _date.today()}
+
+    apply_record_patch(rec, p)
+    _require_fields_for_create(rec)
+    return rec
+
+
+# 공통 정보 생성
+def create_record_common(db: Session, p: Dict[str, Any], *, unique_by_date: bool = True) -> Record:
+    rec = create_record_common_obj(p)
+
+    if unique_by_date:
+        existing = (
+            db.query(Record)
+            .filter(Record.record_date == rec.record_date)
+            .one_or_none()
+        )
+        if existing:
+            raise HTTPException(status_code=409, detail=f"{rec.record_date.isoformat()} 기록이 이미 존재합니다.")
+
+    db.add(rec)
+    db.commit()
+    db.refresh(rec)
+    return rec
+
+
+# 공통 정보 수정
 def apply_record_patch(rec: Record, p: Dict[str, Any]) -> None:
     if "record_date" in p and p["record_date"] is not None:
         rd = p["record_date"]
@@ -132,10 +176,10 @@ def apply_record_patch(rec: Record, p: Dict[str, Any]) -> None:
     if "total_uf" in p and p["total_uf"] is not None:
         rec.total_uf = _as_int_in(p["total_uf"], -5000, 5000, "total_uf")
 
+
 # =========================
 # 회차 공통 처리
 # =========================
-
 def _require_exchange_no(p: Dict[str, Any]) -> int:
     vrng("exchange_no" in p and p["exchange_no"] is not None, "회차(개별)에는 exchange_no가 필요합니다.")
     ex_no = int(p["exchange_no"])
@@ -166,6 +210,7 @@ def patch_exchange(rec: Record, p: Dict[str, Any]) -> RecordExchange:
     _apply_exchange_fields(target, p)
     return target
 
+# 회차 정보 생성
 def create_exchange(rec: Record, p: Dict[str, Any]) -> RecordExchange:
     ex_no = _require_exchange_no(p)
     if find_exchange(rec, ex_no) is not None:


### PR DESCRIPTION
## 📝 작업 내용
기존에 있던 upsert 로직을 제거하고, 기록 날짜가 같은 데이터가 존재할 시 409 에러가 뜨도록 처리하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 동일 날짜의 중복 레코드 생성 시 409 응답으로 차단
  * 레코드 수정 시 날짜 충돌 검증 추가 및 충돌 시 409 반환
  * OCR 처리 중 발생한 HTTP 오류를 일관되게 전파하고 중복 생성 시 409 처리

* **Refactor**
  * 교환(Exchange) 처리 흐름을 생성과 수정으로 명확 분리
  * 숫자·시간 입력 유효성 및 범위 검사 강화
  * 레코드 생성/수정 흐름의 중복·정합성 검사 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->