### PR TITLE
[REFACTOR/#60] 공통 정보 입력 시 기록 아이디 반환

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,4 +1,5 @@
-from fastapi import Depends, HTTPException, APIRouter, UploadFile, File, Response
+from fastapi import Depends, HTTPException, APIRouter, UploadFile, File, Response, status
+from pydantic import BaseModel
 from sqlalchemy import asc
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
@@ -19,20 +20,24 @@ from app.services.recordService import rec_to_dict, apply_record_patch, ex_to_di
 router = APIRouter()
 
 
+class RecordCreateResponse(BaseModel):
+    id: int
+
+
 # 복막투석기록 공통 정보 생성 api
 @router.post(
     "/api/v1/records",
     tags=["복막투석기록-공통"],
     summary="공통 정보 생성",
     description="회차 없이 공통 정보만 생성합니다. 같은 날짜가 이미 있으면 409를 반환합니다.",
-    status_code=204,
-    responses={204: {"description": "성공입니다"}},
+    status_code=status.HTTP_201_CREATED,
+    response_model=RecordCreateResponse,
 )
 def create_record_common_route(payload: RecordCommonCreate, db: Session = Depends(get_db)):
     p = payload.model_dump(exclude_unset=True)
     try:
-        create_record_common(db, p, unique_by_date=True)
-        return Response(status_code=204)
+        rec = create_record_common(db, p, unique_by_date=True)
+        return RecordCreateResponse(id=rec.id)
     except IntegrityError:
         db.rollback()
         raise HTTPException(status_code=409, detail="해당 날짜의 기록이 이미 존재합니다.")

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -139,6 +139,7 @@ def create_record_common(db: Session, p: Dict[str, Any], *, unique_by_date: bool
             raise HTTPException(status_code=409, detail=f"{rec.record_date.isoformat()} 기록이 이미 존재합니다.")
 
     db.add(rec)
+    db.flush()
     db.commit()
     db.refresh(rec)
     return rec


### PR DESCRIPTION
## 📝 작업 내용
기존에는 null 값을 반환하였으나, 회차별 정보 입력 시 기록 아이디가 필요하다고 생각하여 기록 아이디를 반환하는 구조로 변경하였습니다.
<img width="410" height="605" alt="image" src="https://github.com/user-attachments/assets/abc14f19-40d0-4894-9cbe-6231465b91df" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 레코드 생성 API가 이제 생성된 레코드의 ID를 응답으로 반환합니다.
  * 레코드 생성 시 HTTP 상태 코드를 201로 표준화하여 RESTful 규칙을 준수합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->