### PR TITLE
[Feat/#70] 기록 삭제 api 구현

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,5 +1,4 @@
 import hashlib
-from sysconfig import get_scheme_names
 
 from fastapi import Depends, HTTPException, APIRouter, UploadFile, File, Response, status
 from pydantic import BaseModel

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -303,9 +303,16 @@ def ocr_and_save(
             content_type=content_type
         )
 
-        rec.gcs_path = gcs_path_result
-        db.add(rec)
-        db.commit()
+        # 새로운 트랜잭션으로 gcs_path 업데이트
+        try:
+            rec.gcs_path = gcs_path_result
+            db.add(rec)
+            db.commit()
+        except Exception:
+            # GCS 업로드는 성공했지만 DB 업데이트 실패 - GCS 파일 삭제
+            db.rollback()
+            raise
+
 
         # 관계 선로딩 후 스냅샷 반환 + 세션 종료 후 lazy-load 에러 방지
         rec = (

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -242,11 +242,10 @@ def delete_record_route(
 ):
     try:
         delete_record(db, rec_id, current_user.id)
-
         return Response(status_code=204)
 
-    except HTTPException as e:
-        raise e
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"서버 오류 발생: {str(e)}")
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -20,7 +20,7 @@ from app.models.recordSchemas import RecordCommonPatch, RecordCommonCreate, Reco
 from app.services.ocrService import OcrError, ocr_bytes_to_pdrecord_json, save_pdrecord_json, record_to_dict, \
     upload_to_gcs
 from app.services.recordService import rec_to_dict, apply_record_patch, ex_to_dict, create_exchange, \
-    create_record_common, patch_exchange
+    create_record_common, patch_exchange, delete_record
 
 router = APIRouter()
 
@@ -224,6 +224,31 @@ def get_record_exchange_by_id(
     if not row:
         raise HTTPException(status_code=404, detail="해당 회차를 찾을 수 없습니다.")
     return ex_to_dict(row)
+
+
+# 기록 삭제 api
+@router.delete(
+    "/api/v1/records/{rec_id}",
+    tags=["복막투석기록"],
+    summary="기록 삭제",
+    description="특정 아이디의 기록을 삭제합니다. 연관된 회차 정보를 모두 삭제합니다.",
+    status_code=204,
+    responses={204: {"description": "성공입니다"}},
+)
+def delete_record_route(
+        rec_id: int,
+        db: Session = Depends(get_db),
+        current_user: User = Depends(AuthTokenDep)
+):
+    try:
+        delete_record(db, rec_id, current_user.id)
+
+        return Response(status_code=204)
+
+    except HTTPException as e:
+        raise e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"서버 오류 발생: {str(e)}")
 
 
 # 파일 업로드 -> OCR 텍스트 추출 -> JSON 반환 -> db 저장 api

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 
 from fastapi import Depends, HTTPException, APIRouter, UploadFile, File, Response, status
 from pydantic import BaseModel
@@ -18,11 +19,13 @@ from app.core.auth import get_current_active_user as AuthTokenDep
 
 from app.models.recordSchemas import RecordCommonPatch, RecordCommonCreate, RecordExchangeCreate, RecordExchangePatch
 from app.services.ocrService import OcrError, ocr_bytes_to_pdrecord_json, save_pdrecord_json, record_to_dict, \
-    upload_to_gcs
+    upload_to_gcs, delete_from_gcs
 from app.services.recordService import rec_to_dict, apply_record_patch, ex_to_dict, create_exchange, \
     create_record_common, patch_exchange, delete_record
 
 router = APIRouter()
+
+logger = logging.getLogger(__name__)
 
 
 class RecordCreateResponse(BaseModel):
@@ -311,6 +314,10 @@ def ocr_and_save(
         except Exception:
             # GCS 업로드는 성공했지만 DB 업데이트 실패 - GCS 파일 삭제
             db.rollback()
+            try:
+                delete_from_gcs(gcs_path_result)
+            except Exception:
+                logger.exception(f"롤백 중 GCS 파일 삭제 실패: {gcs_path_result}")
             raise
 
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,4 +1,5 @@
 import hashlib
+from sysconfig import get_scheme_names
 
 from fastapi import Depends, HTTPException, APIRouter, UploadFile, File, Response, status
 from pydantic import BaseModel
@@ -296,13 +297,17 @@ def ocr_and_save(
 
         filename = f"ocr_{rec.record_date}_{timestamp}.{ext}"
 
-        upload_to_gcs(
+        gcs_path_result = upload_to_gcs(
             file_bytes=raw,
             user_hash=user_hash,
             record_date=rec.record_date.strftime("%Y%m%d"),
             filename=filename,
             content_type=content_type
         )
+
+        rec.gcs_path = gcs_path_result
+        db.add(rec)
+        db.commit()
 
         # 관계 선로딩 후 스냅샷 반환 + 세션 종료 후 lazy-load 에러 방지
         rec = (

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -247,7 +247,7 @@ def delete_record_route(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"서버 오류 발생: {str(e)}")
+        raise HTTPException(status_code=500, detail="기록 삭제 중 서버 오류가 발생했습니다.") from e
 
 
 # 파일 업로드 -> OCR 텍스트 추출 -> JSON 반환 -> db 저장 api

--- a/app/db_models/record.py
+++ b/app/db_models/record.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, Date, Float, Enum, Text, ForeignKey
+from sqlalchemy import Column, Integer, Date, Float, Enum, Text, ForeignKey, String
 from sqlalchemy.orm import relationship
 
 from app.core.db import Base
@@ -29,6 +29,8 @@ class Record(Base):
     notes = Column(Text, nullable=True) # 비고
 
     total_uf = Column(Integer, nullable=False)  # 제수량 합계
+
+    gcs_path: str = Column(String(512), nullable=True) # GCS에 저장된 OCR 이미지 파일 경로
 
     # 관계: 회차별 데이터
     exchanges = relationship(

--- a/app/db_models/record.py
+++ b/app/db_models/record.py
@@ -30,7 +30,7 @@ class Record(Base):
 
     total_uf = Column(Integer, nullable=False)  # 제수량 합계
 
-    gcs_path: str = Column(String(512), nullable=True) # GCS에 저장된 OCR 이미지 파일 경로
+    gcs_path = Column(String(512), nullable=True) # GCS에 저장된 OCR 이미지 파일 경로
 
     # 관계: 회차별 데이터
     exchanges = relationship(

--- a/app/services/ocrService.py
+++ b/app/services/ocrService.py
@@ -98,10 +98,9 @@ def delete_from_gcs(gcs_path: str) -> bool:
 
         blob.delete()
         logger.info(f"GCS 삭제 완료: gs://{GCS_BUCKET_NAME}/{gcs_path}")
-        return True
     except Exception as e:
-        print(f"GCS 삭제 실패: {type(e).__name__}: {e}")
-        return False
+        logger.exception("GCS 삭제 실패")
+        raise OcrError("GCS 삭제 중 오류가 발생했습니다.", is_client_error=False) from e
 
 
 # 바이트 + MIME 타입을 받아 gemini로 OCR을 수행 -> 텍스트를 json 형태로 반환

--- a/app/services/ocrService.py
+++ b/app/services/ocrService.py
@@ -91,7 +91,7 @@ def download_from_gcs(gcs_path: str) -> bytes:
         raise OcrError("GCS 다운로드 중 오류가 발생했습니다.", is_client_error=False) from e
 
 
-def delete_from_gcs(gcs_path: str) -> bool:
+def delete_from_gcs(gcs_path: str) -> None:
     try:
         bucket = _get_bucket()
         blob = bucket.blob(gcs_path)

--- a/app/services/ocrService.py
+++ b/app/services/ocrService.py
@@ -91,6 +91,19 @@ def download_from_gcs(gcs_path: str) -> bytes:
         raise OcrError("GCS 다운로드 중 오류가 발생했습니다.", is_client_error=False) from e
 
 
+def delete_from_gcs(gcs_path: str) -> bool:
+    try:
+        bucket = _get_bucket()
+        blob = bucket.blob(gcs_path)
+
+        blob.delete()
+        logger.info(f"GCS 삭제 완료: gs://{GCS_BUCKET_NAME}/{gcs_path}")
+        return True
+    except Exception as e:
+        print(f"GCS 삭제 실패: {type(e).__name__}: {e}")
+        return False
+
+
 # 바이트 + MIME 타입을 받아 gemini로 OCR을 수행 -> 텍스트를 json 형태로 반환
 def ocr_bytes_to_pdrecord_json(
     file_bytes: bytes,

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -271,13 +271,14 @@ def delete_record(db: Session, rec_id: int, user_id: int) -> None:
 
     # GCS 이미지 삭제 🗑
     if record.gcs_path:
-        # GCS 삭제 실패는 DB 트랜잭션을 중단시키지 않고 로그만 남기도록 처리
+        # GCS 삭제 실패 시 DB 트랜잭션도 함께 중단
         if not delete_from_gcs(record.gcs_path):
-            # GCS 삭제 실패 시 DB 삭제를 중단하고 500 에러 발생
             raise HTTPException(
                 status_code=500,
                 detail=f"GCS 이미지 삭제(경로: {record.gcs_path})에 실패하여 DB 기록 삭제를 취소합니다. 잠시 후 다시 시도해 주세요."
             )
+        # GCS 장애 시 DB 레코드 삭제 가능해야 함.
+        # delete_from_gcs(record.gcs_path)
 
     # 연관된 exchange 기록 삭제 (cascade 설정에 따라 불필요할 수 있으나 안전을 위해 명시)
     if record.exchanges:

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -249,3 +249,31 @@ def create_exchange(rec: Record, p: Dict[str, Any], user_id: int) -> RecordExcha
     rec.exchanges = (rec.exchanges or [])
     rec.exchanges.append(target)
     return target
+
+
+# 기록 삭제
+def delete_record(db: Session, rec_id: int, user_id: int) -> None:
+
+    record = (
+        db.query(Record)
+        .filter(Record.id == rec_id)
+        .one_or_none()
+    )
+
+    if not record:
+        raise HTTPException(status_code=404, detail=f"기록 ID {rec_id}를 찾을 수 없습니다.")
+
+    # 소유권 검증
+    if record.user_id != user_id:
+        raise HTTPException(status_code=403, detail="기록을 삭제할 권한이 없습니다.")
+
+    # 연관된 exchange 기록 삭제 (cascade 설정에 따라 불필요할 수 있으나 안전을 위해 명시)
+    if record.exchanges:
+        for exchange in record.exchanges:
+            db.delete(exchange)
+
+    # record 삭제
+    db.delete(record)
+
+    db.commit()
+    return

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.db_models.record import Record
 from app.db_models.record_exchange import RecordExchange
-from app.services.ocrService import delete_from_gcs
+from app.services.ocrService import delete_from_gcs, OcrError
 
 
 # =========================
@@ -269,16 +269,16 @@ def delete_record(db: Session, rec_id: int, user_id: int) -> None:
     if record.user_id != user_id:
         raise HTTPException(status_code=403, detail="기록을 삭제할 권한이 없습니다.")
 
-    # GCS 이미지 삭제 🗑
+    # GCS 이미지 삭제
     if record.gcs_path:
         # GCS 삭제 실패 시 DB 트랜잭션도 함께 중단
-        if not delete_from_gcs(record.gcs_path):
+        try:
+            delete_from_gcs(record.gcs_path)
+        except OcrError as e:
             raise HTTPException(
                 status_code=500,
                 detail=f"GCS 이미지 삭제(경로: {record.gcs_path})에 실패하여 DB 기록 삭제를 취소합니다. 잠시 후 다시 시도해 주세요."
-            )
-        # GCS 장애 시 DB 레코드 삭제 가능해야 함.
-        # delete_from_gcs(record.gcs_path)
+            ) from e
 
     # record 삭제
     db.delete(record)

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -280,11 +280,6 @@ def delete_record(db: Session, rec_id: int, user_id: int) -> None:
         # GCS 장애 시 DB 레코드 삭제 가능해야 함.
         # delete_from_gcs(record.gcs_path)
 
-    # 연관된 exchange 기록 삭제 (cascade 설정에 따라 불필요할 수 있으나 안전을 위해 명시)
-    if record.exchanges:
-        for exchange in record.exchanges:
-            db.delete(exchange)
-
     # record 삭제
     db.delete(record)
     db.commit()

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import Session
 
 from app.db_models.record import Record
 from app.db_models.record_exchange import RecordExchange
+from app.services.ocrService import delete_from_gcs
+
 
 # =========================
 # 공통 유틸 / 파서
@@ -267,6 +269,16 @@ def delete_record(db: Session, rec_id: int, user_id: int) -> None:
     if record.user_id != user_id:
         raise HTTPException(status_code=403, detail="기록을 삭제할 권한이 없습니다.")
 
+    # GCS 이미지 삭제 🗑
+    if record.gcs_path:
+        # GCS 삭제 실패는 DB 트랜잭션을 중단시키지 않고 로그만 남기도록 처리
+        if not delete_from_gcs(record.gcs_path):
+            # GCS 삭제 실패 시 DB 삭제를 중단하고 500 에러 발생
+            raise HTTPException(
+                status_code=500,
+                detail=f"GCS 이미지 삭제(경로: {record.gcs_path})에 실패하여 DB 기록 삭제를 취소합니다. 잠시 후 다시 시도해 주세요."
+            )
+
     # 연관된 exchange 기록 삭제 (cascade 설정에 따라 불필요할 수 있으나 안전을 위해 명시)
     if record.exchanges:
         for exchange in record.exchanges:
@@ -274,6 +286,5 @@ def delete_record(db: Session, rec_id: int, user_id: int) -> None:
 
     # record 삭제
     db.delete(record)
-
     db.commit()
     return


### PR DESCRIPTION
## 📝 작업 내용
특정 아이디값을 입력하면 기록을 삭제할 수 있으며, 관련된 회차기록 데이터 또한 모두 삭제됩니다.
Record 테이블에 gcs_path 컬럼을 추가하였으며, 기록 삭제 시GCS에 업로드한 OCR 이미지도 함께 삭제됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자가 API를 통해 자신의 레코드를 삭제할 수 있는 새 엔드포인트가 추가되었습니다.
  * OCR 업로드 흐름에서 클라우드에 업로드된 이미지 경로(gcs_path)가 레코드에 저장되어 조회·관리됩니다.
  * 클라우드 저장소의 개별 파일을 삭제하는 동작이 추가되었습니다.

* **Bug Fixes / 안정성**
  * 삭제 시 존재 확인·소유권 검증·HTTP 오류 응답 처리가 강화되었습니다.
  * 레코드 저장 작업이 트랜잭션으로 안전하게 커밋/롤백되고, 롤백 시 업로드된 클라우드 파일을 삭제하려 시도하도록 안정성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->