### PR TITLE
[Refactor/#73] ocr api 구조 변경

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -296,10 +296,18 @@ def ocr_temp(
             content_type=content_type,
         )
 
-        ocr_data = ocr_bytes_to_pdrecord_json(
-            file_bytes=raw,
-            content_type=content_type,
-        )
+        try:
+            ocr_data = ocr_bytes_to_pdrecord_json(
+                file_bytes=raw,
+                content_type=content_type,
+            )
+        except Exception:
+            # OCR 실패 시 업로드된 GCS 파일 삭제
+            try:
+                delete_from_gcs(gcs_path_result)
+            except Exception:
+                logger.exception("GCS 정리 실패")
+            raise
 
         # 프론트에서 호출 후 수기 작성 api로 저장
         return {
@@ -325,8 +333,14 @@ def ocr_temp(
 )
 def get_ocr_image(
     gcs_path: str = Query(..., description="GCS 내부 경로"),
+    current_user: User = Depends(AuthTokenDep),
 ):
     try:
+        # 경로가 현재 사용자의 경로인지 검증
+        user_hash = hashlib.sha256(str(current_user.id).encode()).hexdigest()[:16]
+        if not gcs_path.startswith(f"users/{user_hash}/"):
+            raise HTTPException(status_code=403, detail="접근 권한이 없습니다.")
+
         # GCS에서 실제 바이트 다운로드
         file_bytes = download_from_gcs(gcs_path)
 
@@ -335,5 +349,11 @@ def get_ocr_image(
             content_type = "image/png"
 
         return Response(content=file_bytes, media_type=content_type)
-    except Exception:
-        raise HTTPException(status_code=404, detail="이미지를 찾을 수 없습니다.")
+    except HTTPException:
+        raise
+    except OcrError as e:
+        status_code = 400 if e.is_client_error() else 500
+        raise HTTPException(status_code=status_code, detail=str(e)) from e
+    except Exception as e:
+        logger.exception("이미지 다운로드 실패")
+        raise HTTPException(status_code=404, detail="이미지를 찾을 수 없습니다.") from e

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -16,6 +16,7 @@ from app.db_models.record_exchange import RecordExchange
 from app.db_models.user import User
 
 from app.core.auth import get_current_active_user as AuthTokenDep
+from app.models.ocrSchemas import OcrSaveRequest
 
 from app.models.recordSchemas import RecordCommonPatch, RecordCommonCreate, RecordExchangeCreate, RecordExchangePatch
 from app.services.ocrService import OcrError, ocr_bytes_to_pdrecord_json, save_pdrecord_json, record_to_dict, \
@@ -253,17 +254,15 @@ def delete_record_route(
         raise HTTPException(status_code=500, detail="기록 삭제 중 서버 오류가 발생했습니다.") from e
 
 
-# 파일 업로드 -> OCR 텍스트 추출 -> JSON 반환 -> db 저장 api
 @router.post(
-    "/api/v1/ocr",
-    tags=["복막투석기록"],
-    summary="ocr 텍스트 추출 후 저장",
-    description="파일을 업로드하면 OCR 기능으로 텍스트를 추출하여 db에 저장합니다."
+    "/api/v1/records/ocr",
+    tags=["복막투석기록-ocr"],
+    summary="OCR 인식 후 텍스트 추출",
+    description="이미지 파일을 업로드하면 OCR을 수행하여 구조화된 JSON과 GCS 경로를 반환합니다.",
 )
-def ocr_and_save(
-        file: UploadFile = File(...),
-        db: Session = Depends(get_db),
-        current_user: User = Depends(AuthTokenDep)
+def ocr_temp(
+    file: UploadFile = File(...),
+    current_user: User = Depends(AuthTokenDep),
 ):
     try:
         raw = file.file.read()
@@ -273,19 +272,9 @@ def ocr_and_save(
         # 사용자 해시값 생성
         user_hash = hashlib.sha256(str(current_user.id).encode()).hexdigest()[:16]
 
-        # 1. OCR만 처리: 409 에러가 발생했음에도 이미지가 저장되는 문제가 존재
-        data = ocr_bytes_to_pdrecord_json(
-            file_bytes=raw,
-            content_type=file.content_type or "application/octet-stream"
-        )
-
-        # 2. DB 저장
-        rec = save_pdrecord_json(data, db, user_id=current_user.id)
-
-        # 3. GCS 업로드
+        # GCS에 이미지 업로드 (추후에 record 삭제하면 gcs_path 컬럼에 담긴 경로 삭제 -> GCS에서 해당 이미지 또한 삭제)
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-        # 파일 MIME 타입에 따라 확장자와 content_type 결정
         content_type = file.content_type or "image/jpeg"
         ext = "jpg"
 
@@ -296,48 +285,33 @@ def ocr_and_save(
             ext = "jpg"
             content_type = "image/jpeg"
 
-        filename = f"ocr_{rec.record_date}_{timestamp}.{ext}"
+        today_str = datetime.now().strftime("%Y%m%d")
+        filename = f"ocr_temp_{timestamp}.{ext}"
 
         gcs_path_result = upload_to_gcs(
             file_bytes=raw,
             user_hash=user_hash,
-            record_date=rec.record_date.strftime("%Y%m%d"),
+            record_date=today_str,
             filename=filename,
-            content_type=content_type
+            content_type=content_type,
         )
 
-        # 새로운 트랜잭션으로 gcs_path 업데이트
-        try:
-            rec.gcs_path = gcs_path_result
-            db.add(rec)
-            db.commit()
-        except Exception:
-            # GCS 업로드는 성공했지만 DB 업데이트 실패 - GCS 파일 삭제
-            db.rollback()
-            try:
-                delete_from_gcs(gcs_path_result)
-            except Exception:
-                logger.exception(f"롤백 중 GCS 파일 삭제 실패: {gcs_path_result}")
-            raise
-
-
-        # 관계 선로딩 후 스냅샷 반환 + 세션 종료 후 lazy-load 에러 방지
-        rec = (
-            db.query(type(rec))
-            .options(joinedload(Record.exchanges))
-            .filter_by(id=rec.id)
-            .one()
+        ocr_data = ocr_bytes_to_pdrecord_json(
+            file_bytes=raw,
+            content_type=content_type,
         )
 
-        return JSONResponse(record_to_dict(rec))
+        # 프론트에서 호출 후 수기 작성 api로 저장
+        return {
+            "gcs_path": gcs_path_result,
+            "ocr_data": ocr_data,
+        }
 
     except OcrError as e:
+        # OCR 관련 커스텀 에러
         status_code = 400 if e.is_client_error() else 500
         raise HTTPException(status_code=status_code, detail=str(e)) from e
     except HTTPException:
         raise
-    except ValueError as e:
-        # save_pdrecord_json 내부 검증(필수값, 형식) 에러
-        raise HTTPException(status_code=422, detail=str(e)) from e
     except Exception as e:
         raise HTTPException(status_code=500, detail="서버 내부 오류가 발생했습니다.") from e

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
 
-from fastapi import Depends, HTTPException, APIRouter, UploadFile, File, Response, status
+from fastapi import Depends, HTTPException, APIRouter, UploadFile, File, Response, status, Query
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
@@ -20,7 +20,7 @@ from app.models.ocrSchemas import OcrSaveRequest
 
 from app.models.recordSchemas import RecordCommonPatch, RecordCommonCreate, RecordExchangeCreate, RecordExchangePatch
 from app.services.ocrService import OcrError, ocr_bytes_to_pdrecord_json, save_pdrecord_json, record_to_dict, \
-    upload_to_gcs, delete_from_gcs
+    upload_to_gcs, delete_from_gcs, download_from_gcs
 from app.services.recordService import rec_to_dict, apply_record_patch, ex_to_dict, create_exchange, \
     create_record_common, patch_exchange, delete_record
 
@@ -315,3 +315,25 @@ def ocr_temp(
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail="서버 내부 오류가 발생했습니다.") from e
+
+
+@router.get(
+    "/api/v1/records/ocr/image",
+    tags=["복막투석기록-ocr"],
+    summary="OCR 이미지 다운로드",
+    description="gcs_path에 해당하는 OCR 이미지를 반환합니다.",
+)
+def get_ocr_image(
+    gcs_path: str = Query(..., description="GCS 내부 경로"),
+):
+    try:
+        # GCS에서 실제 바이트 다운로드
+        file_bytes = download_from_gcs(gcs_path)
+
+        content_type = "image/jpeg"
+        if gcs_path.lower().endswith(".png"):
+            content_type = "image/png"
+
+        return Response(content=file_bytes, media_type=content_type)
+    except Exception:
+        raise HTTPException(status_code=404, detail="이미지를 찾을 수 없습니다.")

--- a/app/db_models/record.py
+++ b/app/db_models/record.py
@@ -28,7 +28,7 @@ class Record(Base):
     turbidity = Column(TurbidityEnum, nullable=False)  # 복막액 혼탁(없음/있음)
     notes = Column(Text, nullable=True) # 비고
 
-    total_uf = Column(Integer, nullable=False)  # 제수량 합계
+    total_uf = Column(Integer, nullable=True)  # 제수량 합계
 
     gcs_path = Column(String(512), nullable=True) # GCS에 저장된 OCR 이미지 파일 경로
 

--- a/app/models/ocrSchemas.py
+++ b/app/models/ocrSchemas.py
@@ -19,5 +19,5 @@ class RecordFinalizeBody(ORMBase):
     fasting_glucose: int
     urine_count: int
     turbidity: str
-    total_uf: int
+    total_uf: Optional[int] = None
     notes: Optional[str] = None

--- a/app/models/ocrSchemas.py
+++ b/app/models/ocrSchemas.py
@@ -1,12 +1,23 @@
+from typing import List, Dict, Any, Optional
+
 from pydantic import BaseModel, ConfigDict
 
 
 class ORMBase(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-class OcrResponse(ORMBase):
-    filename: str
-    content_type: str
-    size_bytes: int
-    model: str
-    text: str
+class OcrSaveRequest(ORMBase):
+    record: Dict[str, Any]
+    gcs_path: str
+
+class RecordFinalizeBody(ORMBase):
+    record_date: str
+    record_dw: str
+    exchanges: List[Dict[str, Any]]
+    weight: float
+    blood_pressure: Dict[str, Optional[int]]
+    fasting_glucose: int
+    urine_count: int
+    turbidity: str
+    total_uf: int
+    notes: Optional[str] = None

--- a/app/models/recordSchemas.py
+++ b/app/models/recordSchemas.py
@@ -31,7 +31,7 @@ class RecordExchangeCreate(ORMBase):
             }
         }
     )
-    exchange_no: Optional[int] = Field(None, ge=1, le=12, description="구분(회차)", json_schema_extra={"readOnly": True})
+    exchange_no: Optional[int] = Field(None, ge=1, le=5, description="구분(회차)", json_schema_extra={"readOnly": True})
     exchange_time: TimeStr = Field(..., description="HH:MM 또는 HH:MM:SS")
     drain_volume: int = Field(..., ge=0, le=6000)
     fill_volume: int = Field(..., ge=0, le=6000)
@@ -91,7 +91,7 @@ class RecordCommonCreate(ORMBase):
     urine_count: int = Field(..., ge=0, le=50)
     turbidity: Turbidity = Field(..., description="혼탁도(없음/있음)")
     notes: Optional[str] = Field(None, max_length=2000)
-    total_uf: int = Field(..., ge=-5000, le=5000)
+    total_uf: Optional[int] = Field(None, ge=-5000, le=5000)
 
 # 공통 정보 수정 스키마
 class RecordCommonPatch(ORMBase):

--- a/app/services/ocrService.py
+++ b/app/services/ocrService.py
@@ -247,7 +247,7 @@ def save_pdrecord_json(data: Dict[str, Any], db: Session, user_id: int) -> Recor
         raise ValueError("turbidity는 '없음' 또는 '있음'이어야 합니다.")
 
     notes = data.get("notes")
-    total_uf = _to_int_required(data.get("total_uf"), "total_uf")
+    total_uf = data.get("total_uf")
 
     # 동일 날짜 존재 여부 체크
     existing = (

--- a/app/services/ocrService.py
+++ b/app/services/ocrService.py
@@ -247,7 +247,13 @@ def save_pdrecord_json(data: Dict[str, Any], db: Session, user_id: int) -> Recor
         raise ValueError("turbidity는 '없음' 또는 '있음'이어야 합니다.")
 
     notes = data.get("notes")
-    total_uf = data.get("total_uf")
+    total_uf_raw = data.get("total_uf")
+    total_uf = None
+    if total_uf_raw is not None:
+        try:
+            total_uf = int(total_uf_raw)
+        except (ValueError, TypeError):
+            raise ValueError(f"제수량 합계는 정수여야 합니다: {total_uf_raw}")
 
     # 동일 날짜 존재 여부 체크
     existing = (

--- a/app/services/ocrService.py
+++ b/app/services/ocrService.py
@@ -252,8 +252,8 @@ def save_pdrecord_json(data: Dict[str, Any], db: Session, user_id: int) -> Recor
     if total_uf_raw is not None:
         try:
             total_uf = int(total_uf_raw)
-        except (ValueError, TypeError):
-            raise ValueError(f"제수량 합계는 정수여야 합니다: {total_uf_raw}")
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"제수량 합계는 정수여야 합니다: {total_uf_raw}") from e
 
     # 동일 날짜 존재 여부 체크
     existing = (

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -36,7 +36,7 @@ def parse_time(s: str) -> dtime:
 def _next_exchange_no(rec: Record) -> int:
     exists = [e.exchange_no for e in (rec.exchanges or [])]
     next_no = (max(exists) + 1) if exists else 1
-    vrng(1 <= next_no <= 12, "최대 12회차까지 등록 가능합니다.")
+    vrng(1 <= next_no <= 5, "최대 5회차까지 등록 가능합니다.")
     return next_no
 
 
@@ -112,7 +112,6 @@ def _require_fields_for_create(rec: Record):
     vrng(rec.fasting_glucose is not None, "fasting_glucose는 필수입니다.")
     vrng(rec.urine_count is not None, "urine_count는 필수입니다.")
     vrng(rec.turbidity in {"없음","있음"}, "turbidity는 '없음' 또는 '있음'이어야 합니다.")
-    vrng(rec.total_uf is not None, "total_uf는 필수입니다.")
 
 
 # 공통 정보 생성용 객체 빌더
@@ -192,7 +191,7 @@ def apply_record_patch(rec: Record, p: Dict[str, Any], user_id: int, check_owner
         rec.notes = str(p["notes"])[:2000]
 
     if "total_uf" in p and p["total_uf"] is not None:
-        rec.total_uf = _as_int_in(p["total_uf"], -5000, 5000, "total_uf")
+        rec.total_uf = p["total_uf"]
 
 
 # =========================
@@ -201,7 +200,7 @@ def apply_record_patch(rec: Record, p: Dict[str, Any], user_id: int, check_owner
 def _require_exchange_no(p: Dict[str, Any]) -> int:
     vrng("exchange_no" in p and p["exchange_no"] is not None, "회차(개별)에는 exchange_no가 필요합니다.")
     ex_no = int(p["exchange_no"])
-    vrng(1 <= ex_no <= 12, "회차는 1~12 범위")
+    vrng(1 <= ex_no <= 5, "회차는 1~5 범위")
     return ex_no
 
 def _apply_exchange_fields(target: RecordExchange, p: Dict[str, Any]) -> None:

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -191,7 +191,7 @@ def apply_record_patch(rec: Record, p: Dict[str, Any], user_id: int, check_owner
         rec.notes = str(p["notes"])[:2000]
 
     if "total_uf" in p and p["total_uf"] is not None:
-        rec.total_uf = p["total_uf"]
+        rec.total_uf = _as_int_in(p["total_uf"], -5000, 5000, "제수량 합계")
 
 
 # =========================


### PR DESCRIPTION
## 📝 작업 내용
ocr 인식 후 텍스트 추출, DB 저장 api를 ocr 인식 후 텍스트 추출 api로, DB에는 저장하지 않는 구조로 변경하였습니다.
또한 gcs_path에 해당하는 OCR 이미지를 반환하는 api를 추가하여, 프론트에서 연동 시 해당 이미지를 가져와서 화면 상단에 미리보기 형태로 제공할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * OCR 이미지 조회용 엔드포인트 추가(업로드된 이미지 직접 다운로드 가능)
  * OCR 결과로 GCS 경로와 구조화된 OCR 데이터 반환

* **변경사항**
  * OCR 처리 흐름을 DB 저장 없이 임시 업로드 기반으로 변경(업로드 후 OCR 처리, 실패 시 업로드 파일 정리)
  * 업로드 검증(빈 파일 차단) 및 권한 검사 강화(소유자 확인)
  * 교환 횟수 제한 12→5로 축소
  * total_uf(총 초여과량) 필드 선택사항화 및 관련 검증/오류 메시지 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->