### PR TITLE
[FEAT/#80] 환자의 최근 3개의 기록 데이터 조회

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -21,7 +21,7 @@ from app.models.recordSchemas import RecordCommonPatch, RecordCommonCreate, Reco
 from app.services.ocrService import OcrError, ocr_bytes_to_pdrecord_json, \
     upload_to_gcs, delete_from_gcs, download_from_gcs
 from app.services.recordService import rec_to_dict, apply_record_patch, ex_to_dict, create_exchange, \
-    create_record_common, patch_exchange, delete_record
+    create_record_common, patch_exchange, delete_record, get_latest_records
 
 router = APIRouter()
 
@@ -214,6 +214,34 @@ def get_records(
         raise HTTPException(
             status_code=500,
             detail="기록 목록 조회 중 서버 오류가 발생했습니다.",
+        ) from e
+
+    if not records:
+        return []
+
+    # 조회된 Record 객체 리스트를 딕셔너리 리스트로 변환하여 반환
+    return [rec_to_dict(rec) for rec in records]
+
+
+@router.get(
+    "/api/v1/records/latest",
+    tags=["복막투석기록"],
+    summary="환자의 가장 최근 3개의 기록 조회",
+    description="환자의 가장 최근 3개의 기록을 조회합니다."
+)
+def get_latest_records_routes(
+        db: Session = Depends(get_db),
+        current_user: User = Depends(AuthTokenDep)
+) -> List[dict]:
+
+    try:
+        records = get_latest_records(db, current_user.id)
+
+    except SQLAlchemyError as e:
+        logging.exception("최신 기록 목록 조회 중 DB 오류 발생")
+        raise HTTPException(
+            status_code=500,
+            detail="최신 기록 목록 조회 중 서버 오류가 발생했습니다.",
         ) from e
 
     if not records:

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -222,14 +222,13 @@ def find_exchange(rec: Record, exchange_no: int) -> Optional[RecordExchange]:
 
 # 환자의 가장 최근 3개의 기록 조회
 def get_latest_records(db: Session, user_id: int) -> List[Record]:
-    LIMIT_COUNT = 3
 
     records = (
         db.query(Record)
         .options(joinedload(Record.exchanges))  # N+1 문제 방지
         .filter(Record.user_id == user_id)
         .order_by(Record.record_date.desc())
-        .limit(LIMIT_COUNT)
+        .limit(3)
         .all()
     )
 

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -1,10 +1,10 @@
 import re
 from datetime import time as dtime, date
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 from datetime import date as _date
 
 from fastapi import HTTPException
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.db_models.record import Record
 from app.db_models.record_exchange import RecordExchange
@@ -218,6 +218,23 @@ def find_exchange(rec: Record, exchange_no: int) -> Optional[RecordExchange]:
         if e.exchange_no == exchange_no:
             return e
     return None
+
+
+# 환자의 가장 최근 3개의 기록 조회
+def get_latest_records(db: Session, user_id: int) -> List[Record]:
+    LIMIT_COUNT = 3
+
+    records = (
+        db.query(Record)
+        .options(joinedload(Record.exchanges))  # N+1 문제 방지
+        .filter(Record.user_id == user_id)
+        .order_by(Record.record_date.desc())
+        .limit(LIMIT_COUNT)
+        .all()
+    )
+
+    return records
+
 
 # 존재하는 회차만 수정
 def patch_exchange(rec: Record, p: Dict[str, Any], user_id: int) -> RecordExchange:


### PR DESCRIPTION
## 📝 작업 내용
limit(3)으로 내림차순으로 필터링하여, 환자의 최근 3개의 기록 데이터를 조회합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 최신 기록을 조회하는 새로운 API 엔드포인트 추가

* **개선사항**
  * 데이터 조회 성능 최적화
  * 기록 수정 시 소유권 검증 강화로 보안 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->