### PR TITLE
[REFACTOR/#86] 회차별 정보 생성/수정 시 리스트 형태로 전달

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -16,13 +16,13 @@ from app.db_models.user import User
 
 from app.core.auth import get_current_active_user as AuthTokenDep
 
-from app.models.recordSchemas import RecordCommonPatch, RecordCommonCreate, RecordExchangeCreate, RecordExchangePatch, \
-    WeeklyAverageResponse, WeeklyAverageData
+from app.models.recordSchemas import RecordCommonPatch, RecordCommonCreate, \
+    WeeklyAverageResponse, WeeklyAverageData, RecordExchangeCreateList, RecordExchangeUpdateList
 from app.services import recordService
 from app.services.ocrService import OcrError, ocr_bytes_to_pdrecord_json, \
     upload_to_gcs, delete_from_gcs, download_from_gcs
-from app.services.recordService import rec_to_dict, apply_record_patch, create_exchange, \
-    create_record_common, patch_exchange, delete_record, get_latest_records
+from app.services.recordService import rec_to_dict, apply_record_patch, \
+    create_record_common, delete_record, get_latest_records, create_exchanges_list, patch_exchanges_list
 
 router = APIRouter()
 
@@ -320,71 +320,34 @@ MAX_EXCHANGES = 5
 )
 def create_record_exchange(
         rec_id: int,
-        payload: RecordExchangeCreate,
+        payload: RecordExchangeCreateList,
         db: Session = Depends(get_db),
         current_user: User = Depends(AuthTokenDep)
 ):
-    rec = (
-        db.query(Record)
-        .options(joinedload(Record.exchanges))
-        .filter(Record.id == rec_id)
-        .first()
-    )
+    create_exchanges_list(db, rec_id, payload.exchanges, user_id=current_user.id)
 
-    if not rec:
-        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
-
-    if rec.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="생성 권한이 없습니다.")
-
-    current_exchange_count = len(rec.exchanges)
-
-    if current_exchange_count >= MAX_EXCHANGES:
-        raise HTTPException(
-            status_code=400,
-            detail=f"기록 하나당 최대 {MAX_EXCHANGES}개의 회차만 생성할 수 있습니다."
-        )
-
-    p = payload.model_dump()
-    create_exchange(rec, p, user_id=current_user.id)
-
-    db.add(rec)
     db.commit()
-    db.refresh(rec)
     return Response(status_code=204)
 
 
 # 복막투석기록 회차 정보 수정 api
 @router.patch(
-    "/api/v1/records/{rec_id}/exchanges/{exchange_no}",
+    "/api/v1/records/{rec_id}/exchanges",
     tags=["복막투석기록-회차"],
     summary="회차 정보 수정",
-    description="특정 기록의 특정 회차 정보를 수정합니다.",
+    description="특정 기록의 회차 정보를 수정합니다.",
     status_code=204,
     responses={204: {"description": "성공입니다"}},
 )
 def patch_record_exchange(
         rec_id: int,
-        exchange_no: int,
-        payload: RecordExchangePatch,
+        payload: RecordExchangeUpdateList,
         db: Session = Depends(get_db),
         current_user: User = Depends(AuthTokenDep)
 ):
-    rec = db.get(Record, rec_id)
-    if not rec:
-        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
+    patch_exchanges_list(db, rec_id, payload.exchanges, user_id=current_user.id)
 
-    if rec.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="수정 권한이 없습니다.")
-
-    p = payload.model_dump(exclude_unset=True)
-    p["exchange_no"] = p.get("exchange_no", exchange_no)
-
-    patch_exchange(rec, p, user_id=current_user.id)
-
-    db.add(rec)
     db.commit()
-    db.refresh(rec)
     return Response(status_code=204)
 
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -336,7 +336,7 @@ def create_record_exchange(
     "/api/v1/records/{rec_id}/exchanges",
     tags=["복막투석기록-회차"],
     summary="회차 정보 수정",
-    description="특정 기록의 회차 정보를 수정합니다.",
+    description="특정 기록의 여러 회차 정보를 한 번에 수정합니다.",
     status_code=204,
     responses={204: {"description": "성공입니다"}},
 )

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -324,7 +324,8 @@ def create_record_exchange(
         db: Session = Depends(get_db),
         current_user: User = Depends(AuthTokenDep)
 ):
-    create_exchanges_list(db, rec_id, payload.exchanges, user_id=current_user.id)
+    exchange_list = [ex.model_dump(exclude_unset=True) for ex in payload.exchanges]
+    create_exchanges_list(db, rec_id, exchange_list, user_id=current_user.id)
 
     db.commit()
     return Response(status_code=204)
@@ -345,7 +346,8 @@ def patch_record_exchange(
         db: Session = Depends(get_db),
         current_user: User = Depends(AuthTokenDep)
 ):
-    patch_exchanges_list(db, rec_id, payload.exchanges, user_id=current_user.id)
+    update_list = [ex.model_dump(exclude_unset=True) for ex in payload.exchanges]
+    patch_exchanges_list(db, rec_id, update_list, user_id=current_user.id)
 
     db.commit()
     return Response(status_code=204)

--- a/app/models/recordSchemas.py
+++ b/app/models/recordSchemas.py
@@ -107,6 +107,7 @@ class RecordExchangePatch(ORMBase):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
+                "id": 123,
                 "exchange_time": "10:30",
                 "drain_volume": 2200
             }

--- a/app/models/recordSchemas.py
+++ b/app/models/recordSchemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime, date
-from typing import Optional, Literal
+from typing import Optional, Literal, List
 from pydantic import BaseModel, Field, ConfigDict, constr
 
 # 오늘 기본값 예시 구성
@@ -19,44 +19,6 @@ class ORMBase(BaseModel):
 
 DayWeekKR = Literal["월", "화", "수", "목", "금", "토", "일"]
 Turbidity = Literal["없음", "있음"]
-
-
-# 회차 정보 생성 스키마
-class RecordExchangeCreate(ORMBase):
-    model_config = ConfigDict(
-        json_schema_extra={
-            "example": {
-                "exchange_time": "09:00",
-                "drain_volume": 2100,
-                "fill_volume": 2000,
-                "fill_concentration": 2.5,
-                "uf": 100
-            }
-        }
-    )
-    exchange_no: Optional[int] = Field(None, ge=1, le=5, description="구분(회차)", json_schema_extra={"readOnly": True})
-    exchange_time: TimeStr = Field(..., description="HH:MM 또는 HH:MM:SS")
-    drain_volume: int = Field(..., ge=0, le=6000)
-    fill_volume: int = Field(..., ge=0, le=6000)
-    fill_concentration: float = Field(..., ge=0, le=100, description="예: 1.5, 2.5, 4.25")
-    uf: int = Field(..., ge=-500, le=500, description="제수량(-500~500)")
-
-
-# 회차 정보 수정 스키마
-class RecordExchangePatch(ORMBase):
-    model_config = ConfigDict(
-        json_schema_extra={
-            "example": {
-                "exchange_time": "10:30",
-                "drain_volume": 2200
-            }
-        }
-    )
-    exchange_time: Optional[str] = None
-    drain_volume: Optional[int] = Field(None, ge=0, le=6000)
-    fill_volume: Optional[int] = Field(None, ge=0, le=6000)
-    fill_concentration: Optional[float] = Field(None, ge=0, le=100)
-    uf: Optional[int] = Field(None, ge=-500, le=500)
 
 
 # 공통 정보 생성 스키마
@@ -112,6 +74,56 @@ class RecordCommonPatch(ORMBase):
     notes: Optional[str] = Field(None, max_length=2000)
     total_uf: Optional[int] = Field(None, ge=-5000, le=5000)
 
+
+# 회차 정보 생성 스키마
+class RecordExchangeCreate(ORMBase):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "exchange_no": 1,
+                "exchange_time": "09:00",
+                "drain_volume": 2100,
+                "fill_volume": 2000,
+                "fill_concentration": 2.5,
+                "uf": 100
+            }
+        }
+    )
+    exchange_no: int = Field(..., ge=1, le=5, description="구분(회차)")
+    exchange_time: TimeStr = Field(..., description="HH:MM 또는 HH:MM:SS")
+    drain_volume: int = Field(..., ge=0, le=6000)
+    fill_volume: int = Field(..., ge=0, le=6000)
+    fill_concentration: float = Field(..., ge=0, le=100, description="예: 1.5, 2.5, 4.25")
+    uf: int = Field(..., ge=-500, le=500, description="제수량(-500~500)")
+
+
+# 회차 정보 생성 요청 스키마 (리스트)
+class RecordExchangeCreateList(ORMBase):
+    exchanges: List[RecordExchangeCreate] = Field(..., description="생성할 회차 기록 리스트")
+
+
+# 회차 정보 수정 스키마
+class RecordExchangePatch(ORMBase):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "exchange_time": "10:30",
+                "drain_volume": 2200
+            }
+        }
+    )
+    exchange_no: Optional[int] = Field(None, ge=1, le=5, description="구분(회차)")
+    exchange_time: Optional[TimeStr] = Field(None, description="HH:MM 또는 HH:MM:SS")
+    drain_volume: Optional[int] = Field(None, ge=0, le=6000)
+    fill_volume: Optional[int] = Field(None, ge=0, le=6000)
+    fill_concentration: Optional[float] = Field(None, ge=0, le=100)
+    uf: Optional[int] = Field(None, ge=-500, le=500)
+
+
+# 회차 정보 수정 요청 스키마 (리스트)
+class RecordExchangeUpdateList(ORMBase):
+    # 단일 API 요청에 포함될 회차 리스트
+    exchanges: List[RecordExchangePatch] = Field(..., description="수정할 회차 기록 리스트")
 
 
 class WeeklyAverageData(BaseModel):

--- a/app/models/recordSchemas.py
+++ b/app/models/recordSchemas.py
@@ -89,7 +89,7 @@ class RecordExchangeCreate(ORMBase):
             }
         }
     )
-    exchange_no: int = Field(..., ge=1, le=5, description="구분(회차)")
+    exchange_no: Optional[int] = Field(None, ge=1, le=5, description="구분(회차)", json_schema_extra={"readOnly": True})
     exchange_time: TimeStr = Field(..., description="HH:MM 또는 HH:MM:SS")
     drain_volume: int = Field(..., ge=0, le=6000)
     fill_volume: int = Field(..., ge=0, le=6000)
@@ -112,6 +112,7 @@ class RecordExchangePatch(ORMBase):
             }
         }
     )
+    id: int = Field(..., description="수정할 회차의 ID")
     exchange_no: Optional[int] = Field(None, ge=1, le=5, description="구분(회차)")
     exchange_time: Optional[TimeStr] = Field(None, description="HH:MM 또는 HH:MM:SS")
     drain_volume: Optional[int] = Field(None, ge=0, le=6000)

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -236,19 +236,57 @@ def get_latest_records(db: Session, user_id: int) -> List[Record]:
     return records
 
 
-# 존재하는 회차만 수정
-def patch_exchange(rec: Record, p: Dict[str, Any], user_id: int) -> RecordExchange:
+# 회차 정보 리스트 생성
+def create_exchanges_list(
+        db: Session,
+        rec_id: int,
+        exchange_list: List[Dict[str, Any]],
+        user_id: int
+) -> Record:
+    rec = (
+        db.query(Record)
+        .options(joinedload(Record.exchanges))
+        .filter(Record.id == rec_id)
+        .first()
+    )
+
+    if not rec:
+        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
 
     # 소유권 검증
     if rec.user_id != user_id:
-        raise HTTPException(status_code=403, detail="기록을 수정할 권한이 없습니다.")
+        raise HTTPException(status_code=403, detail="기록에 회차를 생성할 권한이 없습니다.")
 
-    ex_no = _require_exchange_no(p)
-    target = find_exchange(rec, ex_no)
-    if target is None:
-        raise HTTPException(status_code=404, detail=f"{ex_no}회차가 존재하지 않습니다.")
-    _apply_exchange_fields(target, p)
-    return target
+    # 일괄 생성 로직
+    current_exchange_count = len(rec.exchanges or [])
+    new_exchange_count = len(exchange_list)
+    total_count = current_exchange_count + new_exchange_count
+
+    # 최대 개수 검증
+    vrng(total_count <= 5, "기록 하나당 최대 5개의 회차만 생성할 수 있습니다.")
+
+    for exchange_data in exchange_list:
+
+        # 다음 회차 번호를 계산하고 할당
+        ex_no = _next_exchange_no(rec)
+
+        # 회차 번호가 이미 존재하는지 다시 검사합니다.
+        if find_exchange(rec, ex_no) is not None:
+            raise HTTPException(status_code=409, detail=f"회차 번호 충돌 발생.")
+
+        target = RecordExchange(exchange_no=ex_no, user_id=rec.user_id)
+
+        # 필드 적용 시 시간 파싱 및 범위 검증 수행
+        _apply_exchange_fields(target, exchange_data)
+
+        # 목록에 추가
+        rec.exchanges = (rec.exchanges or [])
+        rec.exchanges.append(target)
+
+    db.add(rec)
+    db.flush()
+    return rec
+
 
 # 회차 정보 생성
 def create_exchange(rec: Record, p: Dict[str, Any], user_id: int) -> RecordExchange:
@@ -267,6 +305,62 @@ def create_exchange(rec: Record, p: Dict[str, Any], user_id: int) -> RecordExcha
 
     rec.exchanges = (rec.exchanges or [])
     rec.exchanges.append(target)
+    return target
+
+
+# 회차 정보 리스트 수정
+def patch_exchanges_list(
+        db: Session,
+        rec_id: int,
+        exchange_update_list: List[Dict[str, Any]],
+        user_id: int
+) -> Record:
+    rec = (
+        db.query(Record)
+        .options(joinedload(Record.exchanges))
+        .filter(Record.id == rec_id)
+        .first()
+    )
+
+    if not rec:
+        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
+
+    # 소유권 검증
+    if rec.user_id != user_id:
+        raise HTTPException(status_code=403, detail="기록을 수정할 권한이 없습니다.")
+
+    # 현재 기록의 회차들을 ID 기준으로 맵핑
+    exchanges_map = {e.id: e for e in (rec.exchanges or [])}
+
+    for update_data in exchange_update_list:
+        exchange_id = update_data.get("id")
+
+        if exchange_id is None:
+            raise HTTPException(status_code=400, detail="회차 수정을 위해서는 'id'가 필수입니다.")
+
+        target = exchanges_map.get(exchange_id)
+
+        if target is None:
+            raise HTTPException(status_code=404, detail=f"회차 ID {exchange_id}를 찾을 수 없습니다.")
+
+        _apply_exchange_fields(target, update_data)
+
+    db.add(rec)
+    db.flush()
+    return rec
+
+# 존재하는 회차만 수정
+def patch_exchange(rec: Record, p: Dict[str, Any], user_id: int) -> RecordExchange:
+
+    # 소유권 검증
+    if rec.user_id != user_id:
+        raise HTTPException(status_code=403, detail="기록을 수정할 권한이 없습니다.")
+
+    ex_no = _require_exchange_no(p)
+    target = find_exchange(rec, ex_no)
+    if target is None:
+        raise HTTPException(status_code=404, detail=f"{ex_no}회차가 존재하지 않습니다.")
+    _apply_exchange_fields(target, p)
     return target
 
 

--- a/app/services/recordService.py
+++ b/app/services/recordService.py
@@ -270,9 +270,9 @@ def create_exchanges_list(
         # 다음 회차 번호를 계산하고 할당
         ex_no = _next_exchange_no(rec)
 
-        # 회차 번호가 이미 존재하는지 다시 검사합니다.
+        # 회차 번호가 이미 존재하는지 다시 검사
         if find_exchange(rec, ex_no) is not None:
-            raise HTTPException(status_code=409, detail=f"회차 번호 충돌 발생.")
+            raise HTTPException(status_code=409, detail="회차 번호 충돌 발생")
 
         target = RecordExchange(exchange_no=ex_no, user_id=rec.user_id)
 
@@ -286,26 +286,6 @@ def create_exchanges_list(
     db.add(rec)
     db.flush()
     return rec
-
-
-# 회차 정보 생성
-def create_exchange(rec: Record, p: Dict[str, Any], user_id: int) -> RecordExchange:
-
-    # 소유권 검증
-    if rec.user_id != user_id:
-        raise HTTPException(status_code=403, detail="기록을 수정할 권한이 없습니다.")
-
-    ex_no = _next_exchange_no(rec)
-
-    if find_exchange(rec, ex_no) is not None:
-        raise HTTPException(status_code=409, detail=f"{ex_no}회차가 이미 존재합니다.")
-
-    target = RecordExchange(exchange_no=ex_no, user_id=rec.user_id)
-    _apply_exchange_fields(target, p)
-
-    rec.exchanges = (rec.exchanges or [])
-    rec.exchanges.append(target)
-    return target
 
 
 # 회차 정보 리스트 수정
@@ -348,20 +328,6 @@ def patch_exchanges_list(
     db.add(rec)
     db.flush()
     return rec
-
-# 존재하는 회차만 수정
-def patch_exchange(rec: Record, p: Dict[str, Any], user_id: int) -> RecordExchange:
-
-    # 소유권 검증
-    if rec.user_id != user_id:
-        raise HTTPException(status_code=403, detail="기록을 수정할 권한이 없습니다.")
-
-    ex_no = _require_exchange_no(p)
-    target = find_exchange(rec, ex_no)
-    if target is None:
-        raise HTTPException(status_code=404, detail=f"{ex_no}회차가 존재하지 않습니다.")
-    _apply_exchange_fields(target, p)
-    return target
 
 
 # 기록 삭제


### PR DESCRIPTION
## 📝 작업 내용
회차별 정보 생성/수정 시 리스트 형태로 전달하여 프론트에서 연동 시 리스트 형태로 요청을 보냅니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 여러 교환 기록을 한 번에 생성 가능
  * 여러 교환 기록을 한 번에 수정 가능

* **변경사항**
  * 교환 생성/수정 요청이 목록 형태의 페이로드를 받도록 변경
  * 수정 엔드포인트 경로 간소화(개별 교환 식별자 경로 제거 → 리스트 기반 처리)
  * 유효성 검사 및 최대 교환 수 제한이 서비스 레이어로 이동하여 일괄 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->