### PR TITLE
[Feat/#83] 전체 상담 기록 조회

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -516,12 +516,28 @@ def get_consult_history_detail_routes(
     db: Session = Depends(get_db),
     current_user: User = Depends(AuthTokenDep),
 ):
-    logs = get_consult_history_detail(db, current_user.id, session_id)
+    try:
+        logs = get_consult_history_detail(db, current_user.id, session_id)
 
-    if not logs:
+        if not logs:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="해당 상담 기록을 찾을 수 없습니다.",
+            )
+
+        return [
+            ConsultMessage(
+                role=log.role,
+                content=log.content,
+                created_at=log.created_at,
+            )
+            for log in logs
+        ]
+    except HTTPException:
+        raise
+    except SQLAlchemyError as e:
+        logger.exception("상담 기록 상세 조회 중 DB 오류 발생")
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="해당 상담 기록을 찾을 수 없습니다.",
-        )
-
-    return [ConsultMessage(**log.__dict__) for log in logs]
+            status_code=500,
+            detail="상담 기록 조회 중 서버 오류가 발생했습니다.",
+        ) from e

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -516,16 +516,11 @@ def get_consult_history_detail_routes(
             detail="해당 상담 기록을 찾을 수 없습니다.",
         )
 
-    result: list[ConsultMessage] = []
-    for log in logs:
-        role_value = log.role.value if hasattr(log.role, "value") else log.role
-
-        result.append(
-            ConsultMessage(
-                role=role_value,
-                content=log.content,
-                created_at=log.created_at,
-            )
+    return [
+        ConsultMessage(
+            role=log.role.value if hasattr(log.role, "value") else log.role,
+            content=log.content,
+            created_at=log.created_at,
         )
-
-    return result
+        for log in logs
+    ]

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -20,10 +20,11 @@ from app.db_models.user import User
 
 from app.core.auth import get_current_active_user as AuthTokenDep
 from app.models.consult_schemas import SessionStartResponse, ChatRequest, SessionEndResponse, \
-    SessionEndRequest, ConsultSessionSummary
+    SessionEndRequest, ConsultSessionSummary, ConsultMessage
 from app.models.record_schemas import WeeklyAverageResponse, WeeklyAverageData, RecordCommonCreate, RecordCommonPatch, \
     RecordExchangeCreateList, RecordExchangeUpdateList
-from app.services.consult_service import start_new_session, get_session_status, get_agent_response_stream, end_session
+from app.services.consult_service import start_new_session, get_session_status, get_agent_response_stream, end_session, \
+    get_consult_history, get_consult_history_detail
 from app.services.ocr_service import upload_to_gcs, ocr_bytes_to_pdrecord_json, delete_from_gcs, OcrError, \
     download_from_gcs
 from app.services.record_service import get_weekly_average_records, create_record_common, rec_to_dict, \
@@ -486,29 +487,45 @@ def end_chat_session(request: SessionEndRequest, current_user: User = Depends(Au
     description="세션별 상담 이력을 하나씩 묶어 전체 상담 기록 목록을 조회합니다.",
     response_model=list[ConsultSessionSummary],
 )
-def get_consult_history(
+def get_consult_history_routes(
     db: Session = Depends(get_db),
     current_user: User = Depends(AuthTokenDep),
 ):
+    summaries_dict = get_consult_history(db, current_user.id)
+    # dict → Pydantic 모델로 변환
+    return [ConsultSessionSummary(**s) for s in summaries_dict]
 
-    rows = (
-        db.query(
-            ConsultLog.session_id.label("session_id"),
-            func.min(ConsultLog.created_at).label("started_at"),
-            func.count(ConsultLog.id).label("message_count"),
-        )
-        .filter(ConsultLog.user_id == current_user.id)
-        .group_by(ConsultLog.session_id)
-        .order_by(func.max(ConsultLog.created_at).desc())  # 최근 상담 먼저
-        .all()
-    )
 
-    # SQLAlchemy Row → Pydantic 모델로 변환
-    return [
-        ConsultSessionSummary(
-            session_id=row.session_id,
-            started_at=row.started_at,
-            message_count=row.message_count,
+@router.get(
+    "/api/v1/consult/history/{session_id}",
+    tags=["에이전트 상담"],
+    summary="특정 상담 세션 상세 조회",
+    description="특정 세션에 대해 상담 로그를 시간순으로 조회합니다.",
+    response_model=list[ConsultMessage],
+)
+def get_consult_history_detail_routes(
+    session_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(AuthTokenDep),
+):
+    logs = get_consult_history_detail(db, current_user.id, session_id)
+
+    if not logs:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="해당 상담 기록을 찾을 수 없습니다.",
         )
-        for row in rows
-    ]
+
+    result: list[ConsultMessage] = []
+    for log in logs:
+        role_value = log.role.value if hasattr(log.role, "value") else log.role
+
+        result.append(
+            ConsultMessage(
+                role=role_value,
+                content=log.content,
+                created_at=log.created_at,
+            )
+        )
+
+    return result

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -10,10 +10,9 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session, joinedload
 from datetime import date as _date, datetime, date
 
-from starlette.responses import JSONResponse, StreamingResponse
+from starlette.responses import StreamingResponse
 
 from app.core.db import get_db
-from app.db_models import ConsultLog
 
 from app.db_models.record import Record
 from app.db_models.user import User
@@ -488,12 +487,21 @@ def end_chat_session(request: SessionEndRequest, current_user: User = Depends(Au
     response_model=list[ConsultSessionSummary],
 )
 def get_consult_history_routes(
+    skip: int = Query(0, ge=0, description="건너뛸 레코드 수"),
+    limit: int = Query(50, ge=1, le=100, description="조회할 최대 레코드 수"),
     db: Session = Depends(get_db),
     current_user: User = Depends(AuthTokenDep),
 ):
-    summaries_dict = get_consult_history(db, current_user.id)
-    # dict → Pydantic 모델로 변환
-    return [ConsultSessionSummary(**s) for s in summaries_dict]
+    try:
+        summaries_dict = get_consult_history(db, current_user.id, skip=skip, limit=limit)
+        # dict → Pydantic 모델로 변환
+        return [ConsultSessionSummary(**s) for s in summaries_dict]
+    except SQLAlchemyError as e:
+        logger.exception("상담 기록 조회 중 DB 오류 발생")
+        raise HTTPException(
+            status_code=500,
+            detail="상담 기록 조회 중 서버 오류가 발생했습니다.",
+        ) from e
 
 
 @router.get(
@@ -516,11 +524,4 @@ def get_consult_history_detail_routes(
             detail="해당 상담 기록을 찾을 수 없습니다.",
         )
 
-    return [
-        ConsultMessage(
-            role=log.role.value if hasattr(log.role, "value") else log.role,
-            content=log.content,
-            created_at=log.created_at,
-        )
-        for log in logs
-    ]
+    return [ConsultMessage(**log.__dict__) for log in logs]

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -13,13 +13,14 @@ from datetime import date as _date, datetime, date
 from starlette.responses import JSONResponse, StreamingResponse
 
 from app.core.db import get_db
+from app.db_models import ConsultLog
 
 from app.db_models.record import Record
 from app.db_models.user import User
 
 from app.core.auth import get_current_active_user as AuthTokenDep
 from app.models.consult_schemas import SessionStartResponse, ChatRequest, SessionEndResponse, \
-    SessionEndRequest
+    SessionEndRequest, ConsultSessionSummary
 from app.models.record_schemas import WeeklyAverageResponse, WeeklyAverageData, RecordCommonCreate, RecordCommonPatch, \
     RecordExchangeCreateList, RecordExchangeUpdateList
 from app.services.consult_service import start_new_session, get_session_status, get_agent_response_stream, end_session
@@ -476,3 +477,38 @@ def end_chat_session(request: SessionEndRequest, current_user: User = Depends(Au
     else:
         # 종료할 세션이 메모리에 없거나 user_id가 소유자와 불일치할 경우 404 에러
         raise HTTPException(status_code=404, detail="종료할 활성화된 세션을 찾을 수 없습니다.")
+
+
+@router.get(
+    "/api/v1/consult/history",
+    tags=["에이전트 상담"],
+    summary="전체 상담 기록 목록 조회",
+    description="세션별 상담 이력을 하나씩 묶어 전체 상담 기록 목록을 조회합니다.",
+    response_model=list[ConsultSessionSummary],
+)
+def get_consult_history(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(AuthTokenDep),
+):
+
+    rows = (
+        db.query(
+            ConsultLog.session_id.label("session_id"),
+            func.min(ConsultLog.created_at).label("started_at"),
+            func.count(ConsultLog.id).label("message_count"),
+        )
+        .filter(ConsultLog.user_id == current_user.id)
+        .group_by(ConsultLog.session_id)
+        .order_by(func.max(ConsultLog.created_at).desc())  # 최근 상담 먼저
+        .all()
+    )
+
+    # SQLAlchemy Row → Pydantic 모델로 변환
+    return [
+        ConsultSessionSummary(
+            session_id=row.session_id,
+            started_at=row.started_at,
+            message_count=row.message_count,
+        )
+        for row in rows
+    ]

--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -1,6 +1,5 @@
+from datetime import datetime
 from uuid import UUID
-
-from pydantic import BaseModel
 
 from app.models.record_schemas import ORMBase
 
@@ -27,3 +26,9 @@ class SessionEndRequest(ORMBase):
 class SessionEndResponse(ORMBase):
     session_id: str
     status: str
+
+
+class ConsultSessionSummary(ORMBase):
+    session_id: str
+    started_at: datetime        # 해당 세션의 첫 메시지 시각
+    message_count: int          # 총 메시지 개수

--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from app.models.record_schemas import ORMBase
@@ -32,3 +33,8 @@ class ConsultSessionSummary(ORMBase):
     session_id: str
     started_at: datetime        # 해당 세션의 첫 메시지 시각
     message_count: int          # 총 메시지 개수
+
+class ConsultMessage(ORMBase):
+    role: Literal["USER", "AGENT"]
+    content: str
+    created_at: datetime

--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -1,8 +1,11 @@
 from datetime import datetime
-from typing import Literal
+from enum import Enum
 
 from app.models.record_schemas import ORMBase
 
+class MessageRole(str, Enum):
+    USER = "USER"
+    AGENT = "AGENT"
 
 # 환영 메시지
 class SessionStartResponse(ORMBase):
@@ -34,6 +37,6 @@ class ConsultSessionSummary(ORMBase):
     message_count: int          # 총 메시지 개수
 
 class ConsultMessage(ORMBase):
-    role: Literal["USER", "AGENT"]
+    role: MessageRole
     content: str
     created_at: datetime

--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -1,13 +1,12 @@
 from datetime import datetime
 from typing import Literal
-from uuid import UUID
 
 from app.models.record_schemas import ORMBase
 
 
 # 환영 메시지
 class SessionStartResponse(ORMBase):
-    session_id: UUID
+    session_id: str
     message: str
 
 

--- a/app/services/consult_service.py
+++ b/app/services/consult_service.py
@@ -4,7 +4,7 @@ from typing import Dict, Any, Generator
 
 from google import genai
 from google.genai import types
-from sqlalchemy import desc, select
+from sqlalchemy import desc, select, func
 from sqlalchemy.orm import Session, selectinload
 
 from app.db_models import Record
@@ -366,3 +366,45 @@ def end_session(user_id: int, session_id: str) -> bool:
         # 메모리에서만 제거 (DB 로그는 유지)
         del active_sessions[session_id]
         return True
+
+
+# 특정 환자의 전체 상담 목록 조회
+def get_consult_history(db: Session, user_id: int) -> list[dict]:
+    rows = (
+        db.query(
+            ConsultLog.session_id.label("session_id"),
+            func.min(ConsultLog.created_at).label("started_at"),
+            func.count().label("message_count"),
+        )
+        .filter(ConsultLog.user_id == user_id)
+        .group_by(ConsultLog.session_id)
+        .order_by(desc(func.max(ConsultLog.created_at)))
+        .all()
+    )
+
+    # 라우터에서 Pydantic으로 감싸기 편하게 dict 리스트로 변환
+    return [
+        {
+            "session_id": r.session_id,
+            "started_at": r.started_at,
+            "message_count": r.message_count,
+        }
+        for r in rows
+    ]
+
+# 특정 환자의 특정 세션에 대한 USER/AGENT 대화 로그 전체를 시간순으로 조회
+def get_consult_history_detail(
+    db: Session,
+    user_id: int,
+    session_id: str,
+):
+    logs = (
+        db.query(ConsultLog)
+        .filter(
+            ConsultLog.user_id == user_id,
+            ConsultLog.session_id == session_id,
+        )
+        .order_by(ConsultLog.created_at.asc())
+        .all()
+    )
+    return logs

--- a/app/services/consult_service.py
+++ b/app/services/consult_service.py
@@ -369,8 +369,8 @@ def end_session(user_id: int, session_id: str) -> bool:
 
 
 # 특정 환자의 전체 상담 목록 조회
-def get_consult_history(db: Session, user_id: int) -> list[dict]:
-    rows = (
+def get_consult_history(db: Session, user_id: int, skip: int = 0, limit: int = 50,) -> list[dict]:
+    base_query = (
         db.query(
             ConsultLog.session_id.label("session_id"),
             func.min(ConsultLog.created_at).label("started_at"),
@@ -379,6 +379,13 @@ def get_consult_history(db: Session, user_id: int) -> list[dict]:
         .filter(ConsultLog.user_id == user_id)
         .group_by(ConsultLog.session_id)
         .order_by(desc(func.max(ConsultLog.created_at)))
+    )
+
+    # 페이징 적용
+    rows = (
+        base_query
+        .offset(skip)
+        .limit(limit)
         .all()
     )
 


### PR DESCRIPTION
## 📝 작업 내용
특정 사용자의 전체 상담 기록을 조회하는 api를 구현하였으며
특정 세션 값으로 USER/AGENT 간 대화 로그를 조회하는 api를 구현하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 상담 내역 목록 조회: 과거 상담 세션 요약(세션 ID, 시작 시각, 메시지 수) 페이징으로 확인 가능.
  * 상담 상세 내역 조회: 특정 세션의 메시지 기록(역할: USER/AGENT, 내용, 생성 시각)을 시간순으로 확인 가능.

* **동작 변경**
  * 세션 ID는 문자열로 전달되며, 존재하지 않는 세션 조회 시 404 응답 반환.

* **버그 수정**
  * DB 오류 발생 시 500 응답 처리 일관성 개선.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->