### PR TITLE
[Feat/#100] 최근 7일간 체중 추이 + 일별 제수량 데이터 조회 api

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -22,12 +22,14 @@ from app.models.consult_schemas import SessionStartResponse, ChatRequest, Sessio
     SessionEndRequest, ConsultSessionSummary, ConsultMessage
 from app.models.record_schemas import WeeklyAverageResponse, WeeklyAverageData, RecordCommonCreate, RecordCommonPatch, \
     RecordExchangeCreateList, RecordExchangeUpdateList
+from app.models.stats_schemas import WeightUfPoint
 from app.services.consult_service import start_new_session, get_session_status, get_agent_response_stream, end_session, \
     get_consult_history, get_consult_history_detail
 from app.services.ocr_service import upload_to_gcs, ocr_bytes_to_pdrecord_json, delete_from_gcs, OcrError, \
     download_from_gcs
 from app.services.record_service import get_weekly_average_records, create_record_common, rec_to_dict, \
     get_latest_records, apply_record_patch, create_exchanges_list, patch_exchanges_list, delete_record
+from app.services.stats_service import get_weight_uf_last_7_days
 
 router = APIRouter()
 
@@ -541,3 +543,27 @@ def get_consult_history_detail_routes(
             status_code=500,
             detail="상담 기록 조회 중 서버 오류가 발생했습니다.",
         ) from e
+
+
+@router.get(
+    "/api/v1/stats/weight-uf-trend",
+    tags=["통계"],
+    summary="최근 7일간 체중 및 일별 제수량 추이 조회",
+    description=(
+        "최근 7일 동안의 체중과 제수량 추이를 반환합니다."
+        "날짜별 기록이 없는 경우 해당 일자는 weight/total_uf가 null로 반환됩니다."
+    ),
+    response_model=List[WeightUfPoint],
+)
+def get_weight_uf_trend(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(AuthTokenDep),
+):
+    try:
+        points = get_weight_uf_last_7_days(db, current_user.id)
+        return points
+    except SQLAlchemyError:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="최근 7일 체중/제수량 통계를 조회하는 중 오류가 발생했습니다.",
+        )

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -415,7 +415,7 @@ def delete_record_route(
         ) from e
 
 
-@router.post("/api/v1/consult/start",
+@router.post("/api/v1/consults/start",
      tags=["에이전트 상담"],
      summary="새로운 복막투석 상담 시작",
      description="새로운 복막투석 상담 세션을 시작하고 고유한 세션 ID를 발급합니다.",
@@ -436,7 +436,7 @@ def start_chat_session(current_user: User = Depends(AuthTokenDep)):
         raise HTTPException(status_code=500, detail="상담 에이전트 서비스 초기화에 실패했습니다. 서버 로그를 확인해주세요.")
 
 
-@router.post("/api/v1/consult/chat",
+@router.post("/api/v1/consults/chat",
      tags=["에이전트 상담"],
      summary="에이전트 대화",
      description="세션 ID를 사용하여 에이전트와 대화를 나눕니다. 응답은 text/plain 형식의 스트리밍으로 실시간 전달됩니다."
@@ -462,7 +462,7 @@ def send_chat_message(request: ChatRequest, db: Session = Depends(get_db), curre
         media_type="text/plain; charset=utf-8",
     )
 
-@router.post("/api/v1/consult/end",
+@router.post("/api/v1/consults/end",
      tags=["에이전트 상담"],
      summary="상담 종료",
      description="활성화된 세션을 종료하고 메모리에서 제거합니다.",
@@ -482,7 +482,7 @@ def end_chat_session(request: SessionEndRequest, current_user: User = Depends(Au
 
 
 @router.get(
-    "/api/v1/consult/history",
+    "/api/v1/consults/history",
     tags=["에이전트 상담"],
     summary="전체 상담 기록 목록 조회",
     description="세션별 상담 이력을 하나씩 묶어 전체 상담 기록 목록을 조회합니다.",
@@ -507,7 +507,7 @@ def get_consult_history_routes(
 
 
 @router.get(
-    "/api/v1/consult/history/{session_id}",
+    "/api/v1/consults/history/{session_id}",
     tags=["에이전트 상담"],
     summary="특정 상담 세션 상세 조회",
     description="특정 세션에 대해 상담 로그를 시간순으로 조회합니다.",

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -562,8 +562,9 @@ def get_weight_uf_trend(
     try:
         points = get_weight_uf_last_7_days(db, current_user.id)
         return points
-    except SQLAlchemyError:
+    except SQLAlchemyError as e:
+        logger.exception("최근 7일 체중/제수량 통계 조회 중 DB 오류 발생")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="최근 7일 체중/제수량 통계를 조회하는 중 오류가 발생했습니다.",
-        )
+        ) from e

--- a/app/models/stats_schemas.py
+++ b/app/models/stats_schemas.py
@@ -1,0 +1,8 @@
+from app.models.record_schemas import ORMBase
+from datetime import date
+
+
+class WeightUfPoint(ORMBase):
+    date: date
+    weight: float | None  # 해당 날짜에 기록 없으면 None
+    total_uf: int | None  # 해당 날짜에 기록 없으면 None

--- a/app/models/stats_schemas.py
+++ b/app/models/stats_schemas.py
@@ -1,8 +1,10 @@
+from pydantic import Field
+
 from app.models.record_schemas import ORMBase
 from datetime import date
 
 
 class WeightUfPoint(ORMBase):
-    date: date
-    weight: float | None  # 해당 날짜에 기록 없으면 None
-    total_uf: int | None  # 해당 날짜에 기록 없으면 None
+    date: date = Field(..., description="기록 날짜")
+    weight: float | None = Field(None, gt=0, description="체중 (kg), 기록 없으면 None")
+    total_uf: int | None = Field(None, description="일별 제수량 합계 (mL), 기록 없으면 None")

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -1,0 +1,59 @@
+from datetime import date, timedelta
+from typing import List
+
+from sqlalchemy import and_
+from sqlalchemy.orm import Session
+
+from app.db_models import Record
+from app.models.stats_schemas import WeightUfPoint
+
+
+# 최근 7일 동안의 일별 체중 & 일별 제수량 추이 조회
+def get_weight_uf_last_7_days(
+    db: Session,
+    user_id: int,
+) -> List[WeightUfPoint]:
+    today = date.today()
+    start_date = today - timedelta(days=6)  # 오늘 포함 최근 7일
+
+    # 1. 최근 7일 사이의 기록만 한 번에 가져오기
+    rows = (
+        db.query(Record)
+        .filter(
+            and_(
+                Record.user_id == user_id,
+                Record.record_date >= start_date,
+                Record.record_date <= today,
+            )
+        )
+        .order_by(Record.record_date.asc())
+        .all()
+    )
+
+    # 2. 날짜별로 접근하기 쉽게 dict로 매핑
+    record_by_date: dict[date, Record] = {
+        r.record_date: r for r in rows
+    }
+
+    # 3. 최근 7일(과거 → 오늘 순)로 list 채우기
+    result: List[WeightUfPoint] = []
+    for offset in range(6, -1, -1):  # 6일 전 → 오늘
+        d = today - timedelta(days=offset)
+        rec = record_by_date.get(d)
+
+        if rec is not None:
+            weight = float(rec.weight) if rec.weight is not None else None
+            total_uf = rec.total_uf if rec.total_uf is not None else None
+        else:
+            weight = None
+            total_uf = None
+
+        result.append(
+            WeightUfPoint(
+                date=d,
+                weight=weight,
+                total_uf=total_uf,
+            )
+        )
+
+    return result

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -42,7 +42,7 @@ def get_weight_uf_last_7_days(
         rec = record_by_date.get(d)
 
         if rec is not None:
-            weight = float(rec.weight) if rec.weight is not None else None
+            weight = rec.weight if rec.weight is not None else None
             total_uf = rec.total_uf if rec.total_uf is not None else None
         else:
             weight = None


### PR DESCRIPTION
## 📝 작업 내용
최근 7일간 체중 추이 + 일별 제수량 데이터 조회 api입니다.
example 데이터를 넣었기 때문에 데이터 값은 같음.
(예시)
```
[
  {
    "date": "2025-11-21",
    "weight": null,
    "total_uf": null
  },
  {
    "date": "2025-11-22",
    "weight": 61.5,
    "total_uf": 150
  },
  {
    "date": "2025-11-23",
    "weight": null,
    "total_uf": null
  },
  {
    "date": "2025-11-24",
    "weight": 61.5,
    "total_uf": 150
  }
]
``` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 최근 7일간의 일별 체중 및 UF 합계 추세를 조회하는 새 통계 엔드포인트 추가(각 항목에 날짜, 체중, 총 UF 포함).

* **API 변경**
  * 상담 관련 공개 경로를 /api/v1/consult/에서 /api/v1/consults/로 업데이트(시작·채팅·종료·히스토리 등).

* **오류 처리**
  * 통계 조회 시 DB 관련 오류에 대해 500 응답을 반환하는 처리 추가.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->