### PR TITLE
[Feat/#105] 기록 작성 & 수정 api

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -20,24 +20,21 @@ from app.db_models.user import User
 from app.core.auth import get_current_active_user as AuthTokenDep
 from app.models.consult_schemas import SessionStartResponse, ChatRequest, SessionEndResponse, \
     SessionEndRequest, ConsultSessionSummary, ConsultMessage
-from app.models.record_schemas import WeeklyAverageResponse, WeeklyAverageData, RecordCommonCreate, RecordCommonPatch, \
-    RecordExchangeCreateList, RecordExchangeUpdateList
+from app.models.record_schemas import WeeklyAverageResponse, WeeklyAverageData, RecordCommonPatch, \
+    RecordExchangeUpdateList, RecordCreate
 from app.models.stats_schemas import WeightUfPoint
 from app.services.consult_service import start_new_session, get_session_status, get_agent_response_stream, end_session, \
     get_consult_history, get_consult_history_detail
 from app.services.ocr_service import upload_to_gcs, ocr_bytes_to_pdrecord_json, delete_from_gcs, OcrError, \
     download_from_gcs
-from app.services.record_service import get_weekly_average_records, create_record_common, rec_to_dict, \
-    get_latest_records, apply_record_patch, create_exchanges_list, patch_exchanges_list, delete_record
+from app.services.record_service import get_weekly_average_records, rec_to_dict, \
+    get_latest_records, apply_record_patch, patch_exchanges_list, delete_record, \
+    create_record_with_exchanges
 from app.services.stats_service import get_weight_uf_last_7_days
 
 router = APIRouter()
 
 logger = logging.getLogger(__name__)
-
-
-class RecordCreateResponse(BaseModel):
-    id: int
 
 
 @router.get("/api/v1/records/weekly-average",
@@ -69,24 +66,22 @@ def get_weekly_average(
         raise HTTPException(status_code=500, detail="주간 평균 계산 중 서버 오류가 발생했습니다.") from e
 
 
-# 복막투석기록 공통 정보 생성 api
 @router.post(
     "/api/v1/records",
-    tags=["복막투석기록-공통"],
-    summary="공통 정보 생성",
-    description="회차 없이 공통 정보만 생성합니다. 같은 날짜가 이미 있으면 409를 반환합니다.",
+    tags=["복막투석기록"],
+    summary="기록 생성",
+    description="복막투석 기록의 공통 정보와 회차별 정보를 한 번에 생성합니다.",
     status_code=status.HTTP_201_CREATED,
-    response_model=RecordCreateResponse,
 )
-def create_record_common_route(
-        payload: RecordCommonCreate,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(AuthTokenDep)
+def create_record_route(
+    payload: RecordCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(AuthTokenDep),
 ):
     p = payload.model_dump(exclude_unset=True)
     try:
-        rec = create_record_common(db, p, user_id=current_user.id, unique_by_date=True)
-        return RecordCreateResponse(id=rec.id)
+        create_record_with_exchanges(db,p,user_id=current_user.id,unique_by_date=True)
+        return Response(status_code=status.HTTP_201_CREATED)
     except IntegrityError:
         db.rollback()
         raise HTTPException(status_code=409, detail="이미 해당 날짜에 기록이 존재합니다.")
@@ -312,31 +307,6 @@ def patch_record_common(
     db.commit()
     db.refresh(rec)
     return Response(status_code=204)
-
-
-MAX_EXCHANGES = 5
-
-# 복막투석기록 회차 정보 생성 api
-@router.post(
-    "/api/v1/records/{rec_id}/exchanges",
-    tags=["복막투석기록-회차"],
-    summary="회차 정보 생성",
-    description="특정 기록에 회차 정보를 생성합니다. 최대 5개까지 작성할 수 있습니다.",
-    status_code=204,
-    responses={204: {"description": "성공입니다"}},
-)
-def create_record_exchange(
-        rec_id: int,
-        payload: RecordExchangeCreateList,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(AuthTokenDep)
-):
-    exchange_list = [ex.model_dump(exclude_unset=True) for ex in payload.exchanges]
-    create_exchanges_list(db, rec_id, exchange_list, user_id=current_user.id)
-
-    db.commit()
-    return Response(status_code=204)
-
 
 # 복막투석기록 회차 정보 수정 api
 @router.patch(

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -279,7 +279,7 @@ def patch_record_route(
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except IntegrityError:
         db.rollback()
-        raise HTTPException(status_code=409, detail="데이터 무결성 오류가 발생했습니다.")
+        raise HTTPException(status_code=409, detail="데이터 무결성 오류가 발생했습니다.") from None
 
 
 # 특정 복막투석기록 조회 api (공통 + 회차)

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -79,7 +79,7 @@ def create_record_route(
 ):
     p = payload.model_dump(exclude_unset=True)
     try:
-        create_record_with_exchanges(db,p,user_id=current_user.id,unique_by_date=True)
+        create_record_with_exchanges(db, p, user_id=current_user.id, unique_by_date=True)
         return Response(status_code=status.HTTP_201_CREATED)
     except IntegrityError:
         db.rollback()
@@ -274,8 +274,12 @@ def patch_record_route(
     current_user: User = Depends(AuthTokenDep),
 ):
     p = payload.model_dump(exclude_unset=True)
-    update_record_with_exchanges(db=db,rec_id=rec_id,p=p,user_id=current_user.id)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    try:
+        update_record_with_exchanges(db=db, rec_id=rec_id, p=p, user_id=current_user.id)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="데이터 무결성 오류가 발생했습니다.")
 
 
 # 특정 복막투석기록 조회 api (공통 + 회차)

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -4,11 +4,10 @@ import uuid
 from typing import List, Optional
 
 from fastapi import Depends, HTTPException, APIRouter, UploadFile, File, Response, status, Query
-from pydantic import BaseModel
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session, joinedload
-from datetime import date as _date, datetime, date
+from datetime import datetime, date
 
 from starlette.responses import StreamingResponse
 
@@ -20,16 +19,16 @@ from app.db_models.user import User
 from app.core.auth import get_current_active_user as AuthTokenDep
 from app.models.consult_schemas import SessionStartResponse, ChatRequest, SessionEndResponse, \
     SessionEndRequest, ConsultSessionSummary, ConsultMessage
-from app.models.record_schemas import WeeklyAverageResponse, WeeklyAverageData, RecordCommonPatch, \
-    RecordExchangeUpdateList, RecordCreate
+from app.models.record_schemas import WeeklyAverageResponse, WeeklyAverageData, \
+    RecordCreate, RecordPatch
 from app.models.stats_schemas import WeightUfPoint
 from app.services.consult_service import start_new_session, get_session_status, get_agent_response_stream, end_session, \
     get_consult_history, get_consult_history_detail
 from app.services.ocr_service import upload_to_gcs, ocr_bytes_to_pdrecord_json, delete_from_gcs, OcrError, \
     download_from_gcs
 from app.services.record_service import get_weekly_average_records, rec_to_dict, \
-    get_latest_records, apply_record_patch, patch_exchanges_list, delete_record, \
-    create_record_with_exchanges
+    get_latest_records, delete_record, \
+    create_record_with_exchanges, update_record_with_exchanges
 from app.services.stats_service import get_weight_uf_last_7_days
 
 router = APIRouter()
@@ -260,74 +259,23 @@ def get_ocr_image(
         raise HTTPException(status_code=404, detail="이미지를 찾을 수 없습니다.") from e
 
 
-# 복막투석기록 공통 정보 수정 api
 @router.patch(
     "/api/v1/records/{rec_id}",
-    tags=["복막투석기록-공통"],
-    summary="공통 정보 수정",
-    description="공통 정보만 부분 수정합니다.",
-    status_code=204,
+    tags=["복막투석기록"],
+    summary="기록 수정",
+    description="복막투석 기록의 공통 정보와 회차별 정보를 한 번에 부분 수정합니다.",
+    status_code=status.HTTP_204_NO_CONTENT,
     responses={204: {"description": "성공입니다"}},
 )
-def patch_record_common(
-        rec_id: int,
-        payload: RecordCommonPatch,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(AuthTokenDep)
+def patch_record_route(
+    rec_id: int,
+    payload: RecordPatch,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(AuthTokenDep),
 ):
-    rec = db.get(Record, rec_id)
-    if not rec:
-        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
-
-    if rec.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="수정 권한이 없습니다.")
-
-    patch = payload.model_dump(exclude_unset=True)
-
-    # record_date가 변경되는 경우, 동일 날짜의 다른 레코드가 있는지 검사
-    if "record_date" in patch and patch["record_date"] is not None:
-        new_date = patch["record_date"]
-        if isinstance(new_date, str):
-            new_date = _date.fromisoformat(new_date)
-        if new_date != rec.record_date:
-            exists = (
-                db.query(Record.id)
-                .filter(
-                    Record.record_date == new_date,
-                    Record.id != rec.id,
-                    Record.user_id == current_user.id)
-                .first()
-            )
-            if exists:
-                raise HTTPException(status_code=409, detail=f"{new_date.isoformat()} 기록이 이미 존재합니다.")
-
-    apply_record_patch(rec, patch, user_id=current_user.id)
-
-    db.add(rec)
-    db.commit()
-    db.refresh(rec)
-    return Response(status_code=204)
-
-# 복막투석기록 회차 정보 수정 api
-@router.patch(
-    "/api/v1/records/{rec_id}/exchanges",
-    tags=["복막투석기록-회차"],
-    summary="회차 정보 수정",
-    description="특정 기록의 여러 회차 정보를 한 번에 수정합니다.",
-    status_code=204,
-    responses={204: {"description": "성공입니다"}},
-)
-def patch_record_exchange(
-        rec_id: int,
-        payload: RecordExchangeUpdateList,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(AuthTokenDep)
-):
-    update_list = [ex.model_dump(exclude_unset=True) for ex in payload.exchanges]
-    patch_exchanges_list(db, rec_id, update_list, user_id=current_user.id)
-
-    db.commit()
-    return Response(status_code=204)
+    p = payload.model_dump(exclude_unset=True)
+    update_record_with_exchanges(db=db,rec_id=rec_id,p=p,user_id=current_user.id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 # 특정 복막투석기록 조회 api (공통 + 회차)

--- a/app/db_models/record.py
+++ b/app/db_models/record.py
@@ -28,7 +28,7 @@ class Record(Base):
     turbidity = Column(TurbidityEnum, nullable=False)  # 복막액 혼탁(없음/있음)
     notes = Column(Text, nullable=True) # 비고
 
-    total_uf = Column(Integer, nullable=True)  # 제수량 합계
+    total_uf = Column(Integer, nullable=False)  # 제수량 합계
 
     gcs_path = Column(String(512), nullable=True) # GCS에 저장된 OCR 이미지 파일 경로
 

--- a/app/models/record_schemas.py
+++ b/app/models/record_schemas.py
@@ -140,10 +140,38 @@ class RecordExchangePatch(ORMBase):
     uf: Optional[int] = Field(None, ge=-500, le=500)
 
 
-# 회차 정보 수정 요청 스키마 (리스트)
-class RecordExchangeUpdateList(ORMBase):
-    # 단일 API 요청에 포함될 회차 리스트
-    exchanges: List[RecordExchangePatch] = Field(..., description="수정할 회차 기록 리스트")
+# 공통 + 회차 정보 동시 수정 스키마
+class RecordPatch(RecordCommonPatch):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "record_date": "2025-11-24",
+                "weight": 56.2,
+                "turbidity": "있음",
+                "notes": "복막액이 약간 혼탁하지만 통증은 없음",
+                "total_uf": 550,
+                "exchanges": [
+                    {
+                        "id": 101,
+                        "exchange_time": "08:30",
+                        "drain_volume": 2150,
+                        "fill_volume": 2000,
+                        "fill_concentration": 1.5,
+                        "uf": 150
+                    },
+                    {
+                        "id": 102,
+                        "drain_volume": 2250,
+                        "uf": 250
+                    }
+                ]
+            }
+        }
+    )
+    exchanges: Optional[List[RecordExchangePatch]] = Field(
+        default=None,
+        description="수정할 회차 기록 리스트 (각 항목은 id 필수, 나머지는 부분 수정 가능)"
+    )
 
 
 class WeeklyAverageData(BaseModel):

--- a/app/models/record_schemas.py
+++ b/app/models/record_schemas.py
@@ -107,17 +107,17 @@ class RecordCreate(ORMBase):
         }
     )
     record_date: Optional[date] = Field(None, description="기록 날짜, 비워두면 오늘 날짜 사용")
-    record_dw: str = Field(..., description="요일: 월/화/수/목/금/토/일")
-    weight: float
-    systolic: int
-    diastolic: int
-    fasting_glucose: int
-    urine_count: int
-    turbidity: str = Field(..., description="'없음' 또는 '있음'")
+    record_dw: DayWeekKR = Field(..., description="요일: 월/화/수/목/금/토/일")
+    weight: float = Field(..., ge=20.0, le=300.0)
+    systolic: int = Field(..., ge=70, le=240)
+    diastolic: int = Field(..., ge=40, le=160)
+    fasting_glucose: int = Field(..., ge=40, le=600)
+    urine_count: int = Field(..., ge=0, le=50)
+    turbidity: Turbidity = Field(..., description="'없음' 또는 '있음'")
     notes: Optional[str] = None
     total_uf: int = Field(..., ge=-5000, le=5000, description="제수량 합계")
     gcs_path: Optional[str] = None
-    exchanges: List[RecordExchangeCreate]
+    exchanges: List[RecordExchangeCreate] = Field(..., min_length=1, max_length=5, description="회차별 정보 (1~5개)")
 
 
 # 회차 정보 수정 스키마

--- a/app/models/record_schemas.py
+++ b/app/models/record_schemas.py
@@ -20,37 +20,6 @@ class ORMBase(BaseModel):
 DayWeekKR = Literal["월", "화", "수", "목", "금", "토", "일"]
 Turbidity = Literal["없음", "있음"]
 
-
-# 공통 정보 생성 스키마
-class RecordCommonCreate(ORMBase):
-    model_config = ConfigDict(
-        json_schema_extra={
-            "example": {
-                "record_date": today_str,
-                "record_dw": today_dw,
-                "weight": 61.5,
-                "systolic": 118,
-                "diastolic": 72,
-                "fasting_glucose": 95,
-                "urine_count": 6,
-                "turbidity": "없음",
-                "notes": "환자의 상태 양호",
-                "total_uf": 150
-            }
-        }
-    )
-    record_date: date = Field(..., description="YYYY-MM-DD")
-    record_dw: DayWeekKR = Field(..., description="요일(월~일)")
-    weight: float = Field(..., ge=20.0, le=300.0)
-    systolic: int = Field(..., ge=70, le=240)
-    diastolic: int = Field(..., ge=40, le=160)
-    fasting_glucose: int = Field(..., ge=40, le=600)
-    urine_count: int = Field(..., ge=0, le=50)
-    turbidity: Turbidity = Field(..., description="혼탁도(없음/있음)")
-    notes: Optional[str] = Field(None, max_length=2000)
-    total_uf: Optional[int] = Field(None, ge=-5000, le=5000)
-
-
 # 공통 정보 수정 스키마
 class RecordCommonPatch(ORMBase):
     model_config = ConfigDict(
@@ -97,9 +66,58 @@ class RecordExchangeCreate(ORMBase):
     uf: int = Field(..., ge=-500, le=500, description="제수량(-500~500)")
 
 
-# 회차 정보 생성 요청 스키마 (리스트)
-class RecordExchangeCreateList(ORMBase):
-    exchanges: List[RecordExchangeCreate] = Field(..., description="생성할 회차 기록 리스트")
+class RecordCreate(ORMBase):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "record_date": "2025-11-24",
+                "record_dw": "월",
+                "weight": 55.8,
+                "systolic": 120,
+                "diastolic": 75,
+                "fasting_glucose": 110,
+                "urine_count": 5,
+                "turbidity": "없음",
+                "notes": "컨디션 양호, 특별한 증상 없음",
+                "total_uf": 600,
+                "exchanges": [
+                    {
+                        "exchange_time": "08:00",
+                        "drain_volume": 2100,
+                        "fill_volume": 2000,
+                        "fill_concentration": 1.5,
+                        "uf": 100
+                    },
+                    {
+                        "exchange_time": "14:00",
+                        "drain_volume": 2300,
+                        "fill_volume": 2000,
+                        "fill_concentration": 2.5,
+                        "uf": 300
+                    },
+                    {
+                        "exchange_time": "20:00",
+                        "drain_volume": 2200,
+                        "fill_volume": 2000,
+                        "fill_concentration": 2.5,
+                        "uf": 200
+                    }
+                ]
+            }
+        }
+    )
+    record_date: Optional[date] = Field(None, description="기록 날짜, 비워두면 오늘 날짜 사용")
+    record_dw: str = Field(..., description="요일: 월/화/수/목/금/토/일")
+    weight: float
+    systolic: int
+    diastolic: int
+    fasting_glucose: int
+    urine_count: int
+    turbidity: str = Field(..., description="'없음' 또는 '있음'")
+    notes: Optional[str] = None
+    total_uf: int = Field(..., ge=-5000, le=5000, description="제수량 합계")
+    gcs_path: Optional[str] = None
+    exchanges: List[RecordExchangeCreate]
 
 
 # 회차 정보 수정 스키마

--- a/app/services/record_service.py
+++ b/app/services/record_service.py
@@ -320,26 +320,6 @@ def get_weekly_average_records(
     return avg_data, start_date, end_date
 
 
-# 제수량 검증
-def _validate_uf_consistency(rec: Record):
-    if not rec.exchanges:
-        vrng(False, "회차 정보가 최소 1개 이상 필요합니다.")
-
-    for e in rec.exchanges:
-        expected_uf = e.drain_volume - e.fill_volume
-        vrng(
-            e.uf == expected_uf,
-            f"{e.exchange_no}회차 제수량이 '배액량 - 주입액 중량'과 일치하지 않습니다."
-        )
-
-    vrng(rec.total_uf is not None, "제수량 합계(total_uf)가 입력되어야 합니다.")
-    sum_uf = sum(e.uf for e in rec.exchanges)
-    vrng(
-        sum_uf == rec.total_uf,
-        "모든 회차 제수량의 합과 제수량 합계(total_uf)가 일치하지 않습니다."
-    )
-
-
 # 공통 정보 + 회차별 정보 한 번에 생성
 def create_record_with_exchanges(
     db: Session,
@@ -398,8 +378,6 @@ def create_record_with_exchanges(
         sum_uf == rec.total_uf,
         "모든 회차 제수량의 합과 제수량 합계가 일치하지 않습니다."
     )
-
-    _validate_uf_consistency(rec)
 
     db.add(rec)
     db.commit()
@@ -476,8 +454,6 @@ def update_record_with_exchanges(
                 )
 
             _apply_exchange_fields(target, update_data)
-
-    _validate_uf_consistency(rec)
 
     db.add(rec)
     db.commit()

--- a/app/services/record_service.py
+++ b/app/services/record_service.py
@@ -320,6 +320,26 @@ def get_weekly_average_records(
     return avg_data, start_date, end_date
 
 
+# 제수량 검증
+def _validate_uf_consistency(rec: Record):
+    if not rec.exchanges:
+        vrng(False, "회차 정보가 최소 1개 이상 필요합니다.")
+
+    for e in rec.exchanges:
+        expected_uf = e.drain_volume - e.fill_volume
+        vrng(
+            e.uf == expected_uf,
+            f"{e.exchange_no}회차 제수량이 '배액량 - 주입액 중량'과 일치하지 않습니다."
+        )
+
+    vrng(rec.total_uf is not None, "제수량 합계(total_uf)가 입력되어야 합니다.")
+    sum_uf = sum(e.uf for e in rec.exchanges)
+    vrng(
+        sum_uf == rec.total_uf,
+        "모든 회차 제수량의 합과 제수량 합계(total_uf)가 일치하지 않습니다."
+    )
+
+
 # 공통 정보 + 회차별 정보 한 번에 생성
 def create_record_with_exchanges(
     db: Session,
@@ -379,7 +399,91 @@ def create_record_with_exchanges(
         "모든 회차 제수량의 합과 제수량 합계가 일치하지 않습니다."
     )
 
+    _validate_uf_consistency(rec)
+
     db.add(rec)
     db.commit()
     db.refresh(rec)
     return rec
+
+
+# 공통 정보 + 회차별 정보 한 번에 수정
+def update_record_with_exchanges(
+    db: Session,
+    rec_id: int,
+    p: Dict[str, Any],
+    user_id: int,
+) -> Record:
+    rec: Optional[Record] = (
+        db.query(Record)
+        .options(joinedload(Record.exchanges))
+        .filter(Record.id == rec_id)
+        .first()
+    )
+
+    if not rec:
+        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
+
+    if rec.user_id != user_id:
+        raise HTTPException(status_code=403, detail="기록을 수정할 권한이 없습니다.")
+
+    # payload 분리
+    exchanges_payload: Optional[List[Dict[str, Any]]] = p.get("exchanges")
+    common_patch = {k: v for k, v in p.items() if k != "exchanges"}
+
+    # 날짜 변경 시 중복 검사
+    if "record_date" in common_patch and common_patch["record_date"] is not None:
+        new_date = common_patch["record_date"]
+        if isinstance(new_date, str):
+            new_date = _date.fromisoformat(new_date)
+
+        if new_date != rec.record_date:
+            exists = (
+                db.query(Record.id)
+                .filter(
+                    Record.record_date == new_date,
+                    Record.id != rec.id,
+                    Record.user_id == user_id,
+                )
+                .first()
+            )
+            if exists:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"{new_date.isoformat()} 기록이 이미 존재합니다."
+                )
+
+    if common_patch:
+        apply_record_patch(rec, common_patch, user_id=user_id, check_ownership=False)
+
+    # 회차 수정
+    if exchanges_payload is not None:
+        exchanges_map = {e.id: e for e in (rec.exchanges or [])}
+
+        for update_data in exchanges_payload:
+            exchange_id = update_data.get("id")
+            if exchange_id is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="회차 수정을 위해서는 'id'가 필수입니다."
+                )
+
+            target = exchanges_map.get(exchange_id)
+            if target is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"회차 ID {exchange_id}를 찾을 수 없습니다."
+                )
+
+            _apply_exchange_fields(target, update_data)
+
+    _validate_uf_consistency(rec)
+
+    db.add(rec)
+    db.commit()
+    db.refresh(rec)
+    return rec
+
+
+
+

--- a/app/services/record_service.py
+++ b/app/services/record_service.py
@@ -354,9 +354,6 @@ def create_record_with_exchanges(
     # 회차 객체들 생성 + 필드 적용
     rec.exchanges = rec.exchanges or []
 
-    if len(exchanges_payload) > 5:
-        raise HTTPException(status_code=400, detail="기록 하나당 최대 5개의 회차만 생성할 수 있습니다.")
-
     for idx, exchange_data in enumerate(exchanges_payload, start=1):
         # 새 기록이므로 1부터 순서대로 회차 번호 부여
         target = RecordExchange(
@@ -365,19 +362,6 @@ def create_record_with_exchanges(
         )
         _apply_exchange_fields(target, exchange_data)
         rec.exchanges.append(target)
-
-    for e in rec.exchanges:
-        expected_uf = e.drain_volume - e.fill_volume
-        vrng(
-            e.uf == expected_uf,
-            f"{e.exchange_no}회차 제수량이 '배액량 - 주입액 중량'과 일치하지 않습니다."
-        )
-
-    sum_uf = sum(e.uf for e in rec.exchanges)
-    vrng(
-        sum_uf == rec.total_uf,
-        "모든 회차 제수량의 합과 제수량 합계가 일치하지 않습니다."
-    )
 
     db.add(rec)
     db.commit()

--- a/app/services/record_service.py
+++ b/app/services/record_service.py
@@ -128,26 +128,6 @@ def create_record_common_obj(p: Dict[str, Any], user_id: int) -> Record:
     return rec
 
 
-# 공통 정보 생성
-def create_record_common(db: Session, p: Dict[str, Any], user_id: int, *, unique_by_date: bool = True) -> Record:
-    rec = create_record_common_obj(p, user_id)
-
-    if unique_by_date:
-        existing = (
-            db.query(Record)
-            .filter(Record.record_date == rec.record_date, Record.user_id==user_id)
-            .one_or_none()
-        )
-        if existing:
-            raise HTTPException(status_code=409, detail=f"{rec.record_date.isoformat()} 기록이 이미 존재합니다.")
-
-    db.add(rec)
-    db.flush()
-    db.commit()
-    db.refresh(rec)
-    return rec
-
-
 # 공통 정보 수정
 def apply_record_patch(rec: Record, p: Dict[str, Any], user_id: int, check_ownership: bool = True) -> None:
 
@@ -195,16 +175,6 @@ def apply_record_patch(rec: Record, p: Dict[str, Any], user_id: int, check_owner
     if "total_uf" in p and p["total_uf"] is not None:
         rec.total_uf = _as_int_in(p["total_uf"], -5000, 5000, "제수량 합계")
 
-
-# =========================
-# 회차 공통 처리
-# =========================
-def _require_exchange_no(p: Dict[str, Any]) -> int:
-    vrng("exchange_no" in p and p["exchange_no"] is not None, "회차(개별)에는 exchange_no가 필요합니다.")
-    ex_no = int(p["exchange_no"])
-    vrng(1 <= ex_no <= 5, "회차는 1~5 범위")
-    return ex_no
-
 def _apply_exchange_fields(target: RecordExchange, p: Dict[str, Any]) -> None:
     _apply_if_present(target, p, "exchange_time", lambda v: parse_time(v))
     _apply_if_present(target, p, "drain_volume", lambda v: _as_int_in(v, 0, 6000, "배액량"))
@@ -234,59 +204,6 @@ def get_latest_records(db: Session, user_id: int) -> List[Record]:
     )
 
     return records
-
-
-# 회차 정보 리스트 생성
-def create_exchanges_list(
-        db: Session,
-        rec_id: int,
-        exchange_list: List[Dict[str, Any]],
-        user_id: int
-) -> Record:
-    rec = (
-        db.query(Record)
-        .options(joinedload(Record.exchanges))
-        .filter(Record.id == rec_id)
-        .first()
-    )
-
-    if not rec:
-        raise HTTPException(status_code=404, detail="복막투석기록을 찾을 수 없습니다.")
-
-    # 소유권 검증
-    if rec.user_id != user_id:
-        raise HTTPException(status_code=403, detail="기록에 회차를 생성할 권한이 없습니다.")
-
-    # 일괄 생성 로직
-    current_exchange_count = len(rec.exchanges or [])
-    new_exchange_count = len(exchange_list)
-    total_count = current_exchange_count + new_exchange_count
-
-    # 최대 개수 검증
-    vrng(total_count <= 5, "기록 하나당 최대 5개의 회차만 생성할 수 있습니다.")
-
-    for exchange_data in exchange_list:
-
-        # 다음 회차 번호를 계산하고 할당
-        ex_no = _next_exchange_no(rec)
-
-        # 회차 번호가 이미 존재하는지 다시 검사
-        if find_exchange(rec, ex_no) is not None:
-            raise HTTPException(status_code=409, detail="회차 번호 충돌 발생")
-
-        target = RecordExchange(exchange_no=ex_no, user_id=rec.user_id)
-
-        # 필드 적용 시 시간 파싱 및 범위 검증 수행
-        _apply_exchange_fields(target, exchange_data)
-
-        # 목록에 추가
-        rec.exchanges = (rec.exchanges or [])
-        rec.exchanges.append(target)
-
-    db.add(rec)
-    db.flush()
-    return rec
-
 
 # 회차 정보 리스트 수정
 def patch_exchanges_list(
@@ -401,3 +318,68 @@ def get_weekly_average_records(
         }
 
     return avg_data, start_date, end_date
+
+
+# 공통 정보 + 회차별 정보 한 번에 생성
+def create_record_with_exchanges(
+    db: Session,
+    p: Dict[str, Any],
+    user_id: int,
+    *,
+    unique_by_date: bool = True,
+) -> Record:
+
+    exchanges_payload: List[Dict[str, Any]] = p.get("exchanges") or []
+    vrng(1 <= len(exchanges_payload) <= 5, "회차는 1~5개까지 입력할 수 있습니다.")
+
+    # exchanges 키는 제거하고 공통 정보만 객체 생성에 사용
+    common_payload = {k: v for k, v in p.items() if k != "exchanges"}
+
+    # Record 객체 생성 (아직 commit X)
+    rec = create_record_common_obj(common_payload, user_id=user_id)
+
+    # 같은 날짜 중복 체크
+    if unique_by_date:
+        existing = (
+            db.query(Record)
+            .filter(Record.record_date == rec.record_date, Record.user_id == user_id)
+            .one_or_none()
+        )
+        if existing:
+            raise HTTPException(
+                status_code=409,
+                detail=f"{rec.record_date.isoformat()} 기록이 이미 존재합니다."
+            )
+
+    # 회차 객체들 생성 + 필드 적용
+    rec.exchanges = rec.exchanges or []
+
+    if len(exchanges_payload) > 5:
+        raise HTTPException(status_code=400, detail="기록 하나당 최대 5개의 회차만 생성할 수 있습니다.")
+
+    for idx, exchange_data in enumerate(exchanges_payload, start=1):
+        # 새 기록이므로 1부터 순서대로 회차 번호 부여
+        target = RecordExchange(
+            exchange_no=idx,
+            user_id=user_id,
+        )
+        _apply_exchange_fields(target, exchange_data)
+        rec.exchanges.append(target)
+
+    for e in rec.exchanges:
+        expected_uf = e.drain_volume - e.fill_volume
+        vrng(
+            e.uf == expected_uf,
+            f"{e.exchange_no}회차 제수량이 '배액량 - 주입액 중량'과 일치하지 않습니다."
+        )
+
+    sum_uf = sum(e.uf for e in rec.exchanges)
+    vrng(
+        sum_uf == rec.total_uf,
+        "모든 회차 제수량의 합과 제수량 합계가 일치하지 않습니다."
+    )
+
+    db.add(rec)
+    db.commit()
+    db.refresh(rec)
+    return rec


### PR DESCRIPTION
## 📝 작업 내용
기존에 구현한 공통 정보 작성 api, 회차별 정보 작성 api를 공통 정보 + 회차별 정보 작성 api로 통일하였습니다. (수정 api도 마찬가지)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API 변경사항**
  * 기록 생성/수정 요청 페이로드가 통합되어 단일 구조로 제출됩니다.
  * POST /records는 201 응답(본문 없음), PATCH /records/{id}는 204 응답(본문 없음)으로 동작합니다.
  * 무결성 충돌 시 409 응답 처리 추가.
  * 생성/수정 시 거래(교환) 항목을 함께 제출·검증(1–5개)하고 순서대로 처리합니다.
* **데이터 변경**
  * total_uf 필드가 필수로 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->