### PR TITLE
[REFACTOR/#110] 전체 상담 기록 조회 시 첫 질문 메시지 반환

### DIFF
--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from enum import Enum
 
+from pydantic import Field
+
 from app.models.record_schemas import ORMBase
 
 class MessageRole(str, Enum):
@@ -33,8 +35,9 @@ class SessionEndResponse(ORMBase):
 
 class ConsultSessionSummary(ORMBase):
     session_id: str
-    started_at: datetime        # 해당 세션의 첫 메시지 시각
-    message_count: int          # 총 메시지 개수
+    started_at: datetime = Field(..., description="해당 세션의 첫 메시지 시각")
+    message_count: int = Field(..., description="총 메시지 개수")
+    first_user_question: str = Field(..., description="환자의 첫 질문")
 
 class ConsultMessage(ORMBase):
     role: MessageRole

--- a/app/services/consult_service.py
+++ b/app/services/consult_service.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session, selectinload
 from app.db_models import Record
 from app.db_models.consult_log import ConsultLog, ConsultRoleEnum
 from app.db_models.kdigo_chunk import KdigoChunk, KDIGO_EMBED_DIM
-
+from app.models.consult_schemas import MessageRole
 
 session_lock = threading.RLock()
 
@@ -393,15 +393,33 @@ def get_consult_history(db: Session, user_id: int, skip: int = 0, limit: int = 5
         .all()
     )
 
-    # 라우터에서 Pydantic으로 감싸기 편하게 dict 리스트로 변환
-    return [
-        {
-            "session_id": r.session_id,
-            "started_at": r.started_at,
-            "message_count": r.message_count,
-        }
-        for r in rows
-    ]
+    result: list[dict] = []
+
+    for r in rows:
+        # 각 세션에서 환자의 첫 질문 메시지 하나 조회
+        first_user = (
+            db.query(ConsultLog.content)
+            .filter(
+                ConsultLog.user_id == user_id,
+                ConsultLog.session_id == r.session_id,
+                ConsultLog.role == MessageRole.USER,
+            )
+            .order_by(ConsultLog.created_at.asc())
+            .first()
+        )
+
+        first_user_question = first_user[0] if first_user is not None else None
+
+        result.append(
+            {
+                "session_id": r.session_id,
+                "started_at": r.started_at,
+                "message_count": r.message_count,
+                "first_user_question": first_user_question,
+            }
+        )
+
+    return result
 
 # 특정 환자의 특정 세션에 대한 USER/AGENT 대화 로그 전체를 시간순으로 조회
 def get_consult_history_detail(


### PR DESCRIPTION
## 📝 작업 내용
전체 기록 조회 시 환자의 첫 질문 메시지도 함께 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 진료 세션 기록에 환자의 첫 질문이 추가되었습니다. 사용자는 이제 상담 이력에서 각 세션의 초기 질문을 바로 확인할 수 있습니다.

* **개선사항**
  * 진료 세션 정보에 더 자세한 설명 메타데이터가 추가되어 데이터의 명확성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->