### PR TITLE
[FEAT/#104] 오늘의 요약 api

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -20,7 +20,7 @@ from app.core.auth import get_current_active_user as AuthTokenDep
 from app.models.consult_schemas import SessionStartResponse, ChatRequest, SessionEndResponse, \
     SessionEndRequest, ConsultSessionSummary, ConsultMessage
 from app.models.record_schemas import \
-    RecordCreate, RecordPatch
+    RecordCreate, RecordPatch, TodayExchangeSummary
 from app.models.stats_schemas import WeightUfPoint, WeeklyAverageResponse, WeeklyAverageData, Last7DaysStats
 from app.services.consult_service import start_new_session, get_session_status, get_agent_response_stream, end_session, \
     get_consult_history, get_consult_history_detail, delete_consult_session
@@ -69,11 +69,12 @@ def get_weekly_average(
     "/api/v1/records/today-summary",
     tags=["복막투석기록"],
     summary="오늘 날짜 교환 요약",
-    description="오늘 날짜의 교환 완료 회차 수와 제수량 합계를 반환합니다."
+    description="오늘 날짜의 교환 완료 회차 수와 제수량 합계를 반환합니다.",
+    response_model=TodayExchangeSummary,
 )
 def api_get_today_exchange_summary(
     db: Session = Depends(get_db),
-    current_user = Depends(AuthTokenDep),
+    current_user: User = Depends(AuthTokenDep),
 ):
     summary = get_today_exchange_summary(
         db=db,

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -28,7 +28,7 @@ from app.services.ocr_service import upload_to_gcs, ocr_bytes_to_pdrecord_json, 
     download_from_gcs
 from app.services.record_service import get_weekly_average_records, rec_to_dict, \
     get_latest_records, delete_record, \
-    create_record_with_exchanges, update_record_with_exchanges
+    create_record_with_exchanges, update_record_with_exchanges, get_today_exchange_summary
 from app.services.stats_service import get_weight_uf_last_7_days
 
 router = APIRouter()
@@ -63,6 +63,23 @@ def get_weekly_average(
     except Exception as e:
         logger.exception("주간 평균 계산 중 예상치 못한 오류 발생")
         raise HTTPException(status_code=500, detail="주간 평균 계산 중 서버 오류가 발생했습니다.") from e
+
+
+@router.get(
+    "/api/v1/records/today-summary",
+    tags=["복막투석기록"],
+    summary="오늘 날짜 교환 요약",
+    description="오늘 날짜의 교환 완료 회차 수와 제수량 합계를 반환합니다."
+)
+def api_get_today_exchange_summary(
+    db: Session = Depends(get_db),
+    current_user = Depends(AuthTokenDep),
+):
+    summary = get_today_exchange_summary(
+        db=db,
+        user_id=current_user.id,
+    )
+    return summary
 
 
 @router.post(

--- a/app/models/record_schemas.py
+++ b/app/models/record_schemas.py
@@ -172,3 +172,8 @@ class RecordPatch(RecordCommonPatch):
         default=None,
         description="수정할 회차 기록 리스트 (각 항목은 id 필수, 나머지는 부분 수정 가능)"
     )
+
+
+class TodayExchangeSummary(BaseModel):
+    exchange_count: int
+    total_uf: int

--- a/app/services/record_service.py
+++ b/app/services/record_service.py
@@ -471,5 +471,38 @@ def update_record_with_exchanges(
     return rec
 
 
+# 오늘 날짜에 대한 완료된 교환 회차 수, 제수량 합계 반환
+def get_today_exchange_summary(
+    db: Session,
+    user_id: int,
+) -> Dict[str, int]:
 
+    today = _date.today()
 
+    rec: Optional[Record] = (
+        db.query(Record)
+        .options(joinedload(Record.exchanges))
+        .filter(
+            Record.user_id == user_id,
+            Record.record_date == today,
+        )
+        .one_or_none()
+    )
+
+    if not rec:
+        return {
+            "exchange_count": 0,
+            "total_uf": 0,
+        }
+
+    exchange_count = len(rec.exchanges or [])
+
+    if rec.total_uf is not None:
+        total_uf = rec.total_uf
+    else:
+        total_uf = sum((e.uf or 0) for e in (rec.exchanges or []))
+
+    return {
+        "exchange_count": exchange_count,
+        "total_uf": total_uf,
+    }

--- a/app/services/record_service.py
+++ b/app/services/record_service.py
@@ -497,10 +497,7 @@ def get_today_exchange_summary(
 
     exchange_count = len(rec.exchanges or [])
 
-    if rec.total_uf is not None:
-        total_uf = rec.total_uf
-    else:
-        total_uf = sum((e.uf or 0) for e in (rec.exchanges or []))
+    total_uf = rec.total_uf
 
     return {
         "exchange_count": exchange_count,


### PR DESCRIPTION
## 📝 작업 내용
오늘의 요약 조회 api에서는 오늘 날짜에 해당하는 사용자의 교환 완료 회차와 제수량 합계를 반환합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 오늘의 환전 현황을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다. 해당 기능으로 오늘의 교환 건수(exchange_count)와 총 환전액(total_uf)을 확인할 수 있습니다.
* 응답은 간단한 요약 형태로 제공되어 대시보드나 리포트에 바로 활용할 수 있습니다.

<sub>✏️ Tip: 설정에서 이 고수준 요약 문구를 맞춤화할 수 있습니다.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->