### PR TITLE
[REFACTOR/#126] 상담 조회 시 반환 데이터들 수정

### DIFF
--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -35,8 +35,7 @@ class SessionEndResponse(ORMBase):
 
 class ConsultSessionSummary(ORMBase):
     session_id: str
-    started_at: datetime = Field(..., description="해당 세션의 첫 메시지 시각")
-    message_count: int = Field(..., description="총 메시지 개수")
+    ended_at: datetime = Field(..., description="해당 세션의 종료 날짜와 시각")
     first_user_question: str = Field(..., description="환자의 첫 질문")
 
 class ConsultMessage(ORMBase):

--- a/app/services/consult_service.py
+++ b/app/services/consult_service.py
@@ -374,12 +374,17 @@ def end_session(user_id: int, session_id: str) -> bool:
 
 
 # 특정 환자의 전체 상담 목록 조회
-def get_consult_history(db: Session, user_id: int, skip: int = 0, limit: int = 50,) -> list[dict]:
+def get_consult_history(
+        db: Session,
+        user_id: int,
+        skip: int = 0,
+        limit: int = 50,
+) -> list[dict]:
+
     base_query = (
         db.query(
             ConsultLog.session_id.label("session_id"),
-            func.min(ConsultLog.created_at).label("started_at"),
-            func.count().label("message_count"),
+            func.max(ConsultLog.created_at).label("ended_at"),
         )
         .filter(ConsultLog.user_id == user_id)
         .group_by(ConsultLog.session_id)
@@ -414,8 +419,7 @@ def get_consult_history(db: Session, user_id: int, skip: int = 0, limit: int = 5
         result.append(
             {
                 "session_id": r.session_id,
-                "started_at": r.started_at,
-                "message_count": r.message_count,
+                "ended_at": r.ended_at,
                 "first_user_question": first_user_question,
             }
         )


### PR DESCRIPTION
## 📝 작업 내용
상담 조회 시 반환 데이터들 수정
(기존) 제목, 상담 시작 날짜, 메시지 개수
(변경) 제목, 상담 종료 날짜

추후에 요약 api 개발한다면, 상담 내용을 요약하여 기록 목록 조회 시 반영 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선사항
* 상담 세션 이력 화면에서 세션의 종료 시간을 새로 표시합니다
* 기존의 세션 시작 시간 및 메시지 개수 정보는 제거됩니다
* 기본 조회 세션 개수를 5개에서 50개로 확대하여 더 많은 이력을 한 번에 확인할 수 있습니다

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->