### PR TITLE
[Feat/#125] 상담 요약 api 개발

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -18,12 +18,12 @@ from app.db_models.user import User
 
 from app.core.auth import get_current_active_user as AuthTokenDep
 from app.models.consult_schemas import SessionStartResponse, ChatRequest, SessionEndResponse, \
-    SessionEndRequest, ConsultSessionSummary, ConsultMessage
+    SessionEndRequest, ConsultMessage, ConsultSession, ConsultSummary
 from app.models.record_schemas import \
     RecordCreate, RecordPatch, TodayExchangeSummary
 from app.models.stats_schemas import WeightUfPoint, WeeklyAverageResponse, WeeklyAverageData, Last7DaysStats
 from app.services.consult_service import start_new_session, get_session_status, get_agent_response_stream, end_session, \
-    get_consult_history, get_consult_history_detail, delete_consult_session
+    get_consult_history, get_consult_history_detail, delete_consult_session, summarize_consult_session
 from app.services.ocr_service import upload_to_gcs, ocr_bytes_to_pdrecord_json, delete_from_gcs, OcrError, \
     download_from_gcs
 from app.services.record_service import get_weekly_average_records, rec_to_dict, \
@@ -423,7 +423,7 @@ def end_chat_session(request: SessionEndRequest, current_user: User = Depends(Au
     tags=["에이전트 상담"],
     summary="전체 상담 기록 목록 조회",
     description="세션별 상담 이력을 하나씩 묶어 전체 상담 기록 목록을 조회합니다.",
-    response_model=list[ConsultSessionSummary],
+    response_model=list[ConsultSession],
 )
 def get_consult_history_routes(
     skip: int = Query(0, ge=0, description="건너뛸 레코드 수"),
@@ -434,7 +434,7 @@ def get_consult_history_routes(
     try:
         summaries_dict = get_consult_history(db, current_user.id, skip=skip, limit=limit)
         # dict → Pydantic 모델로 변환
-        return [ConsultSessionSummary(**s) for s in summaries_dict]
+        return [ConsultSession(**s) for s in summaries_dict]
     except SQLAlchemyError as e:
         logger.exception("상담 기록 조회 중 DB 오류 발생")
         raise HTTPException(
@@ -514,6 +514,40 @@ def delete_consult_session_route(
             status_code=500,
             detail="상담 기록 삭제 중 서버 오류가 발생했습니다.",
         ) from e
+
+
+@router.get(
+    "/api/v1/history/{session_id}/summary",
+    tags=["에이전트 상담"],
+    response_model=ConsultSummary,
+    summary="특정 상담 세션 요약",
+    description="특정 상담 세션이 끝난 후, 전체 상담 내용을 50자~120자 내로 요약하여 제공합니다.",
+)
+def read_consult_summary(
+    session_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(AuthTokenDep),
+):
+
+    # 해당 세션의 로그 존재 여부 체크
+    logs = get_consult_history_detail(
+        db=db,
+        user_id=current_user.id,
+        session_id=session_id,
+    )
+    if not logs:
+        raise HTTPException(status_code=404, detail="해당 세션의 상담 기록이 없습니다.")
+
+    summary_text = summarize_consult_session(
+        db=db,
+        user_id=current_user.id,
+        session_id=session_id,
+    )
+
+    return ConsultSummary(
+        session_id=session_id,
+        summary=summary_text,
+    )
 
 
 @router.get(

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -532,14 +532,6 @@ def create_consult_summary(
     current_user: User = Depends(AuthTokenDep),
 ):
     try:
-        # 이미 요약이 존재하는지 확인
-        existing_summary = get_consult_summary_by_session(db=db, user_id=current_user.id, session_id=session_id)
-        if existing_summary:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="해당 세션의 요약이 이미 존재합니다.",
-            )
-
         summary_text = summarize_consult_session(
             db=db,
             user_id=current_user.id,

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -18,10 +18,10 @@ from app.db_models.user import User
 
 from app.core.auth import get_current_active_user as AuthTokenDep
 from app.models.consult_schemas import SessionStartResponse, ChatRequest, SessionEndResponse, \
-    SessionEndRequest, ConsultMessage, ConsultSession, ConsultSummary
+    SessionEndRequest, ConsultMessage, ConsultSession, ConsultSessionSummaryRow
 from app.models.record_schemas import \
     RecordCreate, RecordPatch, TodayExchangeSummary
-from app.models.stats_schemas import WeightUfPoint, WeeklyAverageResponse, WeeklyAverageData, Last7DaysStats
+from app.models.stats_schemas import WeeklyAverageResponse, WeeklyAverageData, Last7DaysStats
 from app.services.consult_service import start_new_session, get_session_status, get_agent_response_stream, end_session, \
     get_consult_history, get_consult_history_detail, delete_consult_session, summarize_consult_session
 from app.services.ocr_service import upload_to_gcs, ocr_bytes_to_pdrecord_json, delete_from_gcs, OcrError, \
@@ -516,27 +516,18 @@ def delete_consult_session_route(
         ) from e
 
 
-@router.get(
+@router.post(
     "/api/v1/history/{session_id}/summary",
     tags=["에이전트 상담"],
-    response_model=ConsultSummary,
+    response_model=ConsultSessionSummaryRow,
     summary="특정 상담 세션 요약",
     description="특정 상담 세션이 끝난 후, 전체 상담 내용을 50자~120자 내로 요약하여 제공합니다.",
 )
-def read_consult_summary(
+def create_consult_summary(
     session_id: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(AuthTokenDep),
 ):
-
-    # 해당 세션의 로그 존재 여부 체크
-    logs = get_consult_history_detail(
-        db=db,
-        user_id=current_user.id,
-        session_id=session_id,
-    )
-    if not logs:
-        raise HTTPException(status_code=404, detail="해당 세션의 상담 기록이 없습니다.")
 
     summary_text = summarize_consult_session(
         db=db,
@@ -544,7 +535,7 @@ def read_consult_summary(
         session_id=session_id,
     )
 
-    return ConsultSummary(
+    return ConsultSessionSummaryRow(
         session_id=session_id,
         summary=summary_text,
     )

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -23,7 +23,8 @@ from app.models.record_schemas import \
     RecordCreate, RecordPatch, TodayExchangeSummary
 from app.models.stats_schemas import WeeklyAverageResponse, WeeklyAverageData, Last7DaysStats
 from app.services.consult_service import start_new_session, get_session_status, get_agent_response_stream, end_session, \
-    get_consult_history, get_consult_history_detail, delete_consult_session, summarize_consult_session
+    get_consult_history, get_consult_history_detail, delete_consult_session, summarize_consult_session, \
+    get_consult_summary_by_session
 from app.services.ocr_service import upload_to_gcs, ocr_bytes_to_pdrecord_json, delete_from_gcs, OcrError, \
     download_from_gcs
 from app.services.record_service import get_weekly_average_records, rec_to_dict, \
@@ -539,6 +540,33 @@ def create_consult_summary(
         session_id=session_id,
         summary=summary_text,
     )
+
+@router.get(
+    "/api/v1/history/{session_id}/summary",
+    tags=["에이전트 상담"],
+    response_model=ConsultSessionSummaryRow,
+    summary="특정 상담 요약 조회",
+    description="특정 상담의 요약 내용을 조회합니다.",
+)
+def get_consult_summary(
+    session_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(AuthTokenDep),
+):
+    summary_row = get_consult_summary_by_session(
+        db=db,
+        user_id=current_user.id,
+        session_id=session_id,
+    )
+
+    if summary_row is None:
+        # 아직 요약이 생성 안 됐거나, 잘못된 세션 아이디
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="해당 세션의 상담 요약이 존재하지 않습니다.",
+        )
+
+    return summary_row
 
 
 @router.get(

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session, joinedload
 from datetime import datetime, date
 
 from starlette.responses import StreamingResponse
+from starlette.status import HTTP_201_CREATED
 
 from app.core.db import get_db
 
@@ -523,23 +524,47 @@ def delete_consult_session_route(
     response_model=ConsultSessionSummaryRow,
     summary="특정 상담 세션 요약",
     description="특정 상담 세션이 끝난 후, 전체 상담 내용을 50자~120자 내로 요약하여 제공합니다.",
+    status_code=HTTP_201_CREATED,
 )
 def create_consult_summary(
     session_id: str,
     db: Session = Depends(get_db),
     current_user: User = Depends(AuthTokenDep),
 ):
+    try:
+        # 이미 요약이 존재하는지 확인
+        existing_summary = get_consult_summary_by_session(db=db, user_id=current_user.id, session_id=session_id)
+        if existing_summary:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="해당 세션의 요약이 이미 존재합니다.",
+            )
 
-    summary_text = summarize_consult_session(
-        db=db,
-        user_id=current_user.id,
-        session_id=session_id,
-    )
+        summary_text = summarize_consult_session(
+            db=db,
+            user_id=current_user.id,
+            session_id=session_id,
+        )
 
-    return ConsultSessionSummaryRow(
-        session_id=session_id,
-        summary=summary_text,
-    )
+        return ConsultSessionSummaryRow(
+            session_id=session_id,
+            summary=summary_text,
+        )
+    except HTTPException:
+        raise
+    except SQLAlchemyError as e:
+        logger.exception("상담 요약 생성 중 DB 오류 발생")
+        raise HTTPException(
+            status_code=500,
+            detail="상담 요약 생성 중 서버 오류가 발생했습니다.",
+        ) from e
+    except Exception as e:
+        logger.exception("상담 요약 생성 중 예상치 못한 오류 발생")
+        raise HTTPException(
+            status_code=500,
+            detail="상담 요약 생성 중 서버 오류가 발생했습니다.",
+        ) from e
+
 
 @router.get(
     "/api/v1/history/{session_id}/summary",

--- a/app/db_models/__init__.py
+++ b/app/db_models/__init__.py
@@ -4,3 +4,4 @@ from .record import Record
 from .record_exchange import RecordExchange
 from .consult_log import ConsultLog
 from .kdigo_chunk import KdigoChunk
+from .consult_summary import ConsultSummary

--- a/app/db_models/consult_summary.py
+++ b/app/db_models/consult_summary.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from app.core.db import Base
+
+
+class ConsultSummary(Base):
+    __tablename__ = "consult_summary"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    user = relationship("User", back_populates="consult_summary_list")
+
+    session_id = Column(String(64), nullable=False, index=True)
+
+    summary = Column(String(512), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "session_id", name="uq_consult_summary_user_session"),
+    )

--- a/app/db_models/user.py
+++ b/app/db_models/user.py
@@ -42,3 +42,9 @@ class User(Base):
         back_populates="user",
         cascade="all, delete-orphan"
     )
+
+    consult_summary_list = relationship(
+        "ConsultSummary",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )

--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from enum import Enum
+from typing import Optional
 
 from pydantic import Field
 
@@ -36,7 +37,7 @@ class SessionEndResponse(ORMBase):
 class ConsultSession(ORMBase):
     session_id: str
     ended_at: datetime = Field(..., description="해당 세션의 종료 날짜와 시각")
-    first_user_question: str = Field(..., description="환자의 첫 질문")
+    first_user_question: Optional[str] = Field(None, description="환자의 첫 질문")
 
 class ConsultMessage(ORMBase):
     role: MessageRole

--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -45,4 +45,4 @@ class ConsultMessage(ORMBase):
 
 class ConsultSessionSummaryRow(ORMBase):
     session_id: str
-    summary: str = Field(..., description="50~100자 telegram 스타일 상담 요약")
+    summary: str = Field(..., description="50~120자 telegram 스타일 상담 요약")

--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -43,6 +43,6 @@ class ConsultMessage(ORMBase):
     content: str
     created_at: datetime
 
-class ConsultSummary(ORMBase):
+class ConsultSessionSummaryRow(ORMBase):
     session_id: str
     summary: str = Field(..., description="50~100자 telegram 스타일 상담 요약")

--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -45,4 +45,4 @@ class ConsultMessage(ORMBase):
 
 class ConsultSessionSummaryRow(ORMBase):
     session_id: str
-    summary: str = Field(..., description="50~120자 telegram 스타일 상담 요약")
+    summary: str = Field(..., min_length=50, max_length=120, description="50~120자 telegram 스타일 상담 요약")

--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -33,7 +33,7 @@ class SessionEndResponse(ORMBase):
     status: str
 
 
-class ConsultSessionSummary(ORMBase):
+class ConsultSession(ORMBase):
     session_id: str
     ended_at: datetime = Field(..., description="해당 세션의 종료 날짜와 시각")
     first_user_question: str = Field(..., description="환자의 첫 질문")
@@ -42,3 +42,7 @@ class ConsultMessage(ORMBase):
     role: MessageRole
     content: str
     created_at: datetime
+
+class ConsultSummary(ORMBase):
+    session_id: str
+    summary: str = Field(..., description="50~100자 telegram 스타일 상담 요약")

--- a/app/services/consult_service.py
+++ b/app/services/consult_service.py
@@ -627,3 +627,18 @@ def summarize_consult_session(
     db.refresh(summary_row)
 
     return summary_row.summary
+
+
+def get_consult_summary_by_session(
+    db: Session,
+    user_id: int,
+    session_id: str,
+) -> ConsultSummary | None:
+    return (
+        db.query(ConsultSummary)
+        .filter(
+            ConsultSummary.user_id == user_id,
+            ConsultSummary.session_id == session_id,
+        )
+        .first()
+    )

--- a/app/services/consult_service.py
+++ b/app/services/consult_service.py
@@ -2,13 +2,13 @@ import logging
 import threading
 from typing import Dict, Any, Generator
 
+from fastapi import HTTPException, status
 from google import genai
 from google.genai import types
 from sqlalchemy import desc, select, func
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, selectinload
 
-from app.db_models import Record
+from app.db_models import Record, ConsultSummary
 from app.db_models.consult_log import ConsultLog, ConsultRoleEnum
 from app.db_models.kdigo_chunk import KdigoChunk, KDIGO_EMBED_DIM
 from app.models.consult_schemas import MessageRole
@@ -513,6 +513,21 @@ def summarize_consult_session(
     user_id: int,
     session_id: str,
 ) -> str:
+    # 이미 요약이 있는지 확인
+    existing = (
+        db.query(ConsultSummary)
+        .filter(
+            ConsultSummary.user_id == user_id,
+            ConsultSummary.session_id == session_id,
+        )
+        .first()
+    )
+
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="이미 요약이 완료된 상담 세션입니다.",
+        )
 
     # 대화 로그 가져오기
     logs = (
@@ -526,7 +541,10 @@ def summarize_consult_session(
     )
 
     if not logs:
-        return "해당 세션의 상담 기록이 없습니다."
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="해당 세션의 상담 기록이 없습니다.",
+        )
 
     # role: content 형식으로 전체 대화 구성
     conversation_text = "\n".join(
@@ -591,8 +609,21 @@ def summarize_consult_session(
             except Exception as refine_err:
                 logger.error(f"[{session_id}] 요약 길이 보정 중 오류: {refine_err}", exc_info=True)
 
-        return summary_text
-
     except Exception as e:
         logger.error(f"[{session_id}] 상담 요약 생성 실패: {e}", exc_info=True)
-        return "상담 요약 생성 중 오류가 발생했습니다."
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="상담 요약 생성 중 오류가 발생했습니다.",
+        )
+
+    # DB에 저장
+    summary_row = ConsultSummary(
+        user_id=user_id,
+        session_id=session_id,
+        summary=summary_text,
+    )
+    db.add(summary_row)
+    db.commit()
+    db.refresh(summary_row)
+
+    return summary_row.summary

--- a/app/services/consult_service.py
+++ b/app/services/consult_service.py
@@ -463,7 +463,13 @@ def delete_consult_session(
     if not exists:
         return 0
 
-    # 2. 있으면 삭제
+    # 2. 관련 요약 삭제
+    db.query(ConsultSummary).filter(
+        ConsultSummary.user_id == user_id,
+        ConsultSummary.session_id == session_id,
+    ).delete(synchronize_session=False)
+
+    # 3. 로그 삭제
     deleted_count = (
         db.query(ConsultLog)
         .filter(
@@ -614,19 +620,27 @@ def summarize_consult_session(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="상담 요약 생성 중 오류가 발생했습니다.",
+        ) from e
+
+    try:
+        # DB에 저장
+        summary_row = ConsultSummary(
+            user_id=user_id,
+            session_id=session_id,
+            summary=summary_text,
         )
+        db.add(summary_row)
+        db.commit()
+        db.refresh(summary_row)
 
-    # DB에 저장
-    summary_row = ConsultSummary(
-        user_id=user_id,
-        session_id=session_id,
-        summary=summary_text,
-    )
-    db.add(summary_row)
-    db.commit()
-    db.refresh(summary_row)
-
-    return summary_row.summary
+        return summary_row.summary
+    except Exception as e:
+        db.rollback()
+        logger.error(f"[{session_id}] 요약 저장 실패: {e}", exe_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="상담 요약 저장 중 오류가 발생했습니다.",
+        ) from e
 
 
 def get_consult_summary_by_session(

--- a/app/services/consult_service.py
+++ b/app/services/consult_service.py
@@ -531,7 +531,7 @@ def summarize_consult_session(
 
     if existing:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_409_CONFLICT,
             detail="이미 요약이 완료된 상담 세션입니다.",
         )
 
@@ -636,7 +636,7 @@ def summarize_consult_session(
         return summary_row.summary
     except Exception as e:
         db.rollback()
-        logger.error(f"[{session_id}] 요약 저장 실패: {e}", exe_info=True)
+        logger.error(f"[{session_id}] 요약 저장 실패: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="상담 요약 저장 중 오류가 발생했습니다.",

--- a/app/services/consult_service.py
+++ b/app/services/consult_service.py
@@ -474,3 +474,125 @@ def delete_consult_session(
     )
     db.commit()
     return deleted_count
+
+
+# 전보(telegram) 스타일 요약 프롬프트
+SUMMARY_SYSTEM_PROMPT = """
+You are an AI assistant that summarizes one completed consultation session for a patient undergoing peritoneal dialysis.
+
+[Goal]
+- Produce ONE short, natural-sounding "telegram style" summary (~50–100 chars).
+- Tone should be concise but not overly formal or stiff. 
+- Avoid mechanical or bureaucratic expressions. Aim for a natural, smooth Korean summary.
+
+[Content]
+- Compress all patient questions into 2–3 short topic phrases (Examples. "체중 증가·부종", "혈압 관리", "식단 고민").
+- Compress the agent's guidance into 1–2 short actionable phrases (Examples. "수분·염분 조절", "매일 체중 확인", "의료진과 조율").
+- The final sentence should follow this pattern: "[patient topics], [main guidance/조언]."
+- Keep wording compact but readable; avoid overly scientific tone unless necessary.
+
+[Style Rules]
+- Language MUST match the main language of the conversation.
+- Output MUST be: 
+  - a single sentence
+  - 50–120 characters ideally (minimum 50)
+  - no greetings, no politeness, no emoji
+  - no quotation marks, no bullet points, no line breaks
+- Use comma-based, telegraphic style typical of Korean telegram summaries.
+- Keep it natural and fluid (e.g., “~고민”, “~조언”, “~확인”, “~조율” 등).
+
+[Examples]
+- “체중·부종·식단 고민, 수분·염분 줄이고 매일 체중 확인하며 치료 방향 조율”
+- “혈압·운동·수분 섭취 문의, 혈압 기록·수분 제한·운동 강도는 의료진과 조율”
+"""
+
+# 특정 세션의 전체 상담 내용을 50~100자 전보 스타일로 요약
+# 환자 질문은 2~3개 주제 토픽으로, 에이전트 답변은 1~2개 핵심 조언으로 압축
+def summarize_consult_session(
+    db: Session,
+    user_id: int,
+    session_id: str,
+) -> str:
+
+    # 대화 로그 가져오기
+    logs = (
+        db.query(ConsultLog)
+        .filter(
+            ConsultLog.user_id == user_id,
+            ConsultLog.session_id == session_id,
+        )
+        .order_by(ConsultLog.created_at.asc())
+        .all()
+    )
+
+    if not logs:
+        return "해당 세션의 상담 기록이 없습니다."
+
+    # role: content 형식으로 전체 대화 구성
+    conversation_text = "\n".join(
+        f"{(log.role.value if hasattr(log.role, 'value') else log.role)}: {log.content}"
+        for log in logs
+    )
+
+    if client is None:
+        # 첫 100자를 잘라서 반환
+        text = conversation_text.replace("\n", " ")
+        return (text[:100] + "...") if len(text) > 100 else text
+
+    try:
+        # 요약 생성 프롬프트
+        prompt = (
+            "Summarize the following consultation between a patient and an AI agent into ONE telegram-style line.\n"
+            "- Compress all patient questions into 2–3 short topic phrases (Examples. 'weight gain and swelling', 'blood pressure control').\n"
+            "- Compress the agent's answers into 1–2 short phrases describing the main guidance.\n"
+            "- Use the main language of the conversation (Korean or English).\n"
+            "- The summary MUST be at least 50 characters long and ideally within 100–120 characters in total,\n"
+            "  with no greetings, no politeness, no emoji, no quotation marks, no bullet points, no line breaks.\n"
+            "- Prefer dense, comma-separated phrases rather than a polite full sentence.\n\n"
+            "--- Conversation ---\n"
+            f"{conversation_text}\n"
+        )
+
+        resp = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                system_instruction=SUMMARY_SYSTEM_PROMPT
+            )
+        )
+
+        summary_text = (resp.text or "").strip()
+        summary_text = " ".join(summary_text.split())
+
+        # 50자 미만이면 한 번 더 요청
+        if len(summary_text) < 50:
+            try:
+                refine_prompt = (
+                    "The following summary is too short. Rewrite it as ONE telegram-style line "
+                    "with at least 50 and at most about 120 characters, keeping the same meaning.\n"
+                    "- No greetings, no politeness, no emoji, no quotation marks, no bullet points, no line breaks.\n"
+                    "- Use compact, comma-separated phrases instead of a polite full sentence.\n\n"
+                    f"Original summary:\n{summary_text}"
+                )
+
+                refine_resp = client.models.generate_content(
+                    model="gemini-2.5-flash",
+                    contents=refine_prompt,
+                    config=types.GenerateContentConfig(
+                        system_instruction=SUMMARY_SYSTEM_PROMPT
+                    )
+                )
+
+                refined = (refine_resp.text or "").strip()
+                refined = " ".join(refined.split())
+
+                if len(refined) >= 50:
+                    summary_text = refined
+            except Exception as refine_err:
+                logger.error(f"[{session_id}] 요약 길이 보정 중 오류: {refine_err}", exc_info=True)
+
+        return summary_text
+
+    except Exception as e:
+        logger.error(f"[{session_id}] 상담 요약 생성 실패: {e}", exc_info=True)
+        return "상담 요약 생성 중 오류가 발생했습니다."


### PR DESCRIPTION
## 📝 작업 내용
세션이 종료되면 전체 상담 내용을 50~100자 정도로 요약, 전보(telegram) 스타일
프론트 연동 후에 프롬프트 개선해도 되기 때문에.. 기능 먼저 합치고 추후에 ocr 프롬프트나 에이전트 프롬프트나 손 보는걸로..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상담 세션 요약 생성(POST) 및 조회(GET) API 추가
  * Telegram 스타일 자동 요약 생성(50~120자) 및 저장 지원

* **개선 사항**
  * 상담 이력 응답이 세션 단위 객체로 노출되도록 데이터 형태 업데이트
  * 중복 요약 방지(409), 요약 부재(404) 및 처리 실패(500)에 대한 명확한 응답 처리 추가

* **기타**
  * 사용자별 상담 요약 연계·관리 기능 보강

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->