### PR TITLE
[REFACTOR/#132] 상담 요약 조회 구조 변경

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -24,8 +24,7 @@ from app.models.record_schemas import \
     RecordCreate, RecordPatch, TodayExchangeSummary
 from app.models.stats_schemas import WeeklyAverageResponse, WeeklyAverageData, Last7DaysStats
 from app.services.consult_service import start_new_session, get_session_status, get_agent_response_stream, end_session, \
-    get_consult_history, get_consult_history_detail, delete_consult_session, summarize_consult_session, \
-    get_consult_summary_by_session
+    get_consult_history, get_consult_history_detail, delete_consult_session, summarize_consult_session
 from app.services.ocr_service import upload_to_gcs, ocr_bytes_to_pdrecord_json, delete_from_gcs, OcrError, \
     download_from_gcs
 from app.services.record_service import get_weekly_average_records, rec_to_dict, \
@@ -556,34 +555,6 @@ def create_consult_summary(
             status_code=500,
             detail="상담 요약 생성 중 서버 오류가 발생했습니다.",
         ) from e
-
-
-@router.get(
-    "/api/v1/consults/{session_id}/summary",
-    tags=["에이전트 상담"],
-    response_model=ConsultSessionSummaryRow,
-    summary="특정 상담 요약 조회",
-    description="특정 상담의 요약 내용을 조회합니다.",
-)
-def get_consult_summary(
-    session_id: str,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(AuthTokenDep),
-):
-    summary_row = get_consult_summary_by_session(
-        db=db,
-        user_id=current_user.id,
-        session_id=session_id,
-    )
-
-    if summary_row is None:
-        # 아직 요약이 생성 안 됐거나, 잘못된 세션 아이디
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="해당 세션의 상담 요약이 존재하지 않습니다.",
-        )
-
-    return summary_row
 
 
 @router.get(

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -423,7 +423,7 @@ def end_chat_session(request: SessionEndRequest, current_user: User = Depends(Au
     "/api/v1/consults",
     tags=["에이전트 상담"],
     summary="전체 상담 기록 목록 조회",
-    description="세션별 상담 이력을 하나씩 묶어 전체 상담 기록 목록을 조회합니다.",
+    description="세션별 상담 이력을 하나씩 묶어 전체 상담 기록 목록을 조회합니다. 각 세션에 요약이 존재하면 함께 반환됩니다.",
     response_model=list[ConsultSession],
 )
 def get_consult_history_routes(

--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -38,6 +38,7 @@ class ConsultSession(ORMBase):
     session_id: str
     ended_at: datetime = Field(..., description="해당 세션의 종료 날짜와 시각")
     first_user_question: Optional[str] = Field(None, description="환자의 첫 질문")
+    summary: Optional[str] = Field(None, min_length=50, max_length=120, description="전보(telegram) 스타일 상담 요약")
 
 class ConsultMessage(ORMBase):
     role: MessageRole

--- a/app/services/consult_service.py
+++ b/app/services/consult_service.py
@@ -381,19 +381,29 @@ def get_consult_history(
         limit: int = 50,
 ) -> list[dict]:
 
-    base_query = (
+    # 유저별 세션 목록 + 마지막 시간만 뽑는 서브쿼리
+    base_subq = (
         db.query(
             ConsultLog.session_id.label("session_id"),
             func.max(ConsultLog.created_at).label("ended_at"),
         )
         .filter(ConsultLog.user_id == user_id)
         .group_by(ConsultLog.session_id)
-        .order_by(desc(func.max(ConsultLog.created_at)))
-    )
+    ).subquery()
 
-    # 페이징 적용
+    # 서브쿼리에 consult_summary를 LEFT JOIN 해서 summary 같이 가져오기
     rows = (
-        base_query
+        db.query(
+            base_subq.c.session_id,
+            base_subq.c.ended_at,
+            ConsultSummary.summary,
+        )
+        .outerjoin(
+            ConsultSummary,
+            (ConsultSummary.user_id == user_id) &
+            (ConsultSummary.session_id == base_subq.c.session_id),
+        )
+        .order_by(desc(base_subq.c.ended_at))
         .offset(skip)
         .limit(limit)
         .all()
@@ -421,6 +431,7 @@ def get_consult_history(
                 "session_id": r.session_id,
                 "ended_at": r.ended_at,
                 "first_user_question": first_user_question,
+                "summary": r.summary,
             }
         )
 
@@ -641,18 +652,3 @@ def summarize_consult_session(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="상담 요약 저장 중 오류가 발생했습니다.",
         ) from e
-
-
-def get_consult_summary_by_session(
-    db: Session,
-    user_id: int,
-    session_id: str,
-) -> ConsultSummary | None:
-    return (
-        db.query(ConsultSummary)
-        .filter(
-            ConsultSummary.user_id == user_id,
-            ConsultSummary.session_id == session_id,
-        )
-        .first()
-    )


### PR DESCRIPTION
## 📝 작업 내용
상담 요약 조회 구조 변경하였습니다.
(기존) 상담 요약 조회 api가 따로 존재하여 비용 발생
(변경) 상담 요약 테이블을 left join 처리하여, 특정 환자의 전체 상담 목록 조회 시 함께 반환하도록 수정
기존에 작성한 상담 세션 요약 조회 로직 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Breaking Changes**
  * 특정 세션의 요약을 조회하는 API 엔드포인트 제거
  
* **Data Model Updates**
  * 상담 세션 데이터에 요약 필드 추가 (50-120자)
  
* **Improvements**
  * 상담 내역 조회 시 요약 정보 포함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->