### PR TITLE
[BUG/#135] 상담 요약 길이 제약 삭제

### DIFF
--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -38,7 +38,7 @@ class ConsultSession(ORMBase):
     session_id: str
     ended_at: datetime = Field(..., description="해당 세션의 종료 날짜와 시각")
     first_user_question: Optional[str] = Field(None, description="환자의 첫 질문")
-    summary: Optional[str] = Field(None, min_length=50, max_length=120, description="전보(telegram) 스타일 상담 요약")
+    summary: Optional[str] = Field(None, description="전보(telegram) 스타일 상담 요약")
 
 class ConsultMessage(ORMBase):
     role: MessageRole


### PR DESCRIPTION
## 📝 작업 내용
스키마의 summary에 요약 길이가 최소 50자로 제약되어 있어, 상담 내용을 요약했을 때 50자 미만인 경우 응답 검증용 에러가 발생

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 상담 요약 입력 필드에 적용되던 글자 수 제한(최소 50자, 최대 120자)을 제거하였습니다. 사용자가 더욱 자유롭게 상담 내용을 요약하고 입력할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->