### PR TITLE
[BUG/#137] 상담 요약 길이 제약 삭제

### DIFF
--- a/app/models/consult_schemas.py
+++ b/app/models/consult_schemas.py
@@ -47,4 +47,4 @@ class ConsultMessage(ORMBase):
 
 class ConsultSessionSummaryRow(ORMBase):
     session_id: str
-    summary: str = Field(..., min_length=50, max_length=120, description="50~120자 telegram 스타일 상담 요약")
+    summary: str = Field(..., description="전보(telegram) 스타일 상담 요약")


### PR DESCRIPTION
## 📝 작업 내용
스키마의 summary에 요약 길이가 최소 50자로 제약되어 있어, 상담 내용을 요약했을 때 50자 미만인 경우 응답 검증용 에러가 발생

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **기타**
  * 상담 요약 필드에서 길이 제약 조건이 제거되었습니다. 이전에는 최소 50자에서 최대 120자로 엄격하게 제한되었으나, 이제 사용자는 필요에 따라 더 자유롭게 상담 내용을 요약할 수 있습니다. 필드 설명도 함께 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->