### PR TITLE
[REFACTOR/#152] 오늘의 요약에서 회차별 제수량 합계 반환

### DIFF
--- a/app/models/record_schemas.py
+++ b/app/models/record_schemas.py
@@ -178,3 +178,4 @@ class TodayExchangeSummary(BaseModel):
     has_record: bool = Field(..., description="오늘 날짜에 복막투석 기록이 존재하는지의 여부", examples=[True])
     exchange_count: int = Field(..., ge=0, le=5, description="오늘 완료된 교환 회차 개수", examples=[4])
     total_uf: int = Field(..., ge=-2500, le=2500, description="오늘의 제수량 합계 (단위: g)", examples=[500])
+    record_uf_sum: int = Field(..., ge=-2500, le=2500, description="회차별 제수량 합계 (단위: g)", examples=[500])

--- a/app/services/record_service.py
+++ b/app/services/record_service.py
@@ -501,14 +501,20 @@ def get_today_exchange_summary(
         return TodayExchangeSummary(
             has_record=False,
             exchange_count=0,
-            total_uf=0
+            total_uf=0,
+            record_uf_sum=0
         )
+
+    exchanges = rec.exchanges or [] # 오늘 기록이 있는 경우
 
     exchange_count = len(rec.exchanges or [])
     total_uf = rec.total_uf or 0
+
+    record_uf_sum = sum((e.uf or 0) for e in exchanges)
 
     return TodayExchangeSummary(
         has_record=True,
         exchange_count=exchange_count,
         total_uf=total_uf,
+        record_uf_sum=record_uf_sum,
     )


### PR DESCRIPTION
## 📝 작업 내용
오늘의 요약에서 회차별 제수량 합계 반환 (total_uf x)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일일 환전 요약에 환전별 제수량 합계 정보가 추가되었습니다. 사용자는 당일 모든 환전 거래의 제수량 합계를 자동으로 계산하여 한눈에 확인할 수 있습니다. 환전 현황을 더욱 정확하게 파악할 수 있게 되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->